### PR TITLE
Add LinksPage and related services and view models

### DIFF
--- a/AMFormsCST.Core/Interfaces/ILinksService.cs
+++ b/AMFormsCST.Core/Interfaces/ILinksService.cs
@@ -1,0 +1,7 @@
+namespace AMFormsCST.Core.Interfaces
+{
+    public interface ILinksService
+    {
+        void OpenLink(string linkKey);
+    }
+}

--- a/AMFormsCST.Desktop/AMFormsCST.Desktop.csproj
+++ b/AMFormsCST.Desktop/AMFormsCST.Desktop.csproj
@@ -7,16 +7,20 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Assets\Solera_Logo_Symbol_Only.ico</ApplicationIcon>
-    <AssemblyVersion>2.1.0</AssemblyVersion>
+    <AssemblyVersion>2.2.0</AssemblyVersion>
     <FileVersion>$(assemblyversion)</FileVersion>
     <Version>$(assemblyversion)</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="Helpers\**" />
+    <Compile Remove="Releases\**" />
     <EmbeddedResource Remove="Helpers\**" />
+    <EmbeddedResource Remove="Releases\**" />
     <None Remove="Helpers\**" />
+    <None Remove="Releases\**" />
     <Page Remove="Helpers\**" />
+    <Page Remove="Releases\**" />
   </ItemGroup>
 	
 	<ItemGroup>

--- a/AMFormsCST.Desktop/App.xaml.cs
+++ b/AMFormsCST.Desktop/App.xaml.cs
@@ -15,17 +15,19 @@ using AMFormsCST.Desktop.Models.UserSettings;
 using AMFormsCST.Desktop.Resources;
 using AMFormsCST.Desktop.Services;
 using AMFormsCST.Desktop.ViewModels;
+using AMFormsCST.Desktop.ViewModels.Dialogs;
 using AMFormsCST.Desktop.ViewModels.Pages;
+using AMFormsCST.Desktop.ViewModels.Pages.Links;
 using AMFormsCST.Desktop.ViewModels.Pages.Tools;
+using AMFormsCST.Desktop.Views.Dialogs;
 using AMFormsCST.Desktop.Views.Pages;
+using AMFormsCST.Desktop.Views.Pages.Links;
 using AMFormsCST.Desktop.Views.Pages.Tools;
 using Lepo.i18n.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Serilog;
-using Serilog.Extensions.Logging;
 using Serilog.Formatting.Compact;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -97,6 +99,8 @@ public partial class App : Application
                 _ = services.AddSingleton<ToolsViewModel>();
                 _ = services.AddSingleton<SettingsPage>();
                 _ = services.AddSingleton<SettingsViewModel>();
+                _ = services.AddSingleton<LinksPage>();
+                _ = services.AddSingleton<LinksViewModel>();
 
                 _ = services.AddTransientFromNamespace("AMFormsCST.Desktop.Views", GalleryAssembly.Assembly);
                 _ = services.AddTransientFromNamespace(
@@ -126,6 +130,10 @@ public partial class App : Application
                 _ = services.AddSingleton<IUiSettings, UiSettings>();
                 _ = services.AddSingleton<IUserSettings, UserSettings>();
                 _ = services.AddSingleton<ISettings, Settings>();
+                _ = services.AddSingleton<ILinksService, LinksService>();
+
+                _ = services.AddTransient<AddLinkDialogPage>();
+                _ = services.AddTransient<AddLinkDialogViewModel>();
 
                 _ = services.AddStringLocalizer(b =>
                 {

--- a/AMFormsCST.Desktop/MainWindow.xaml.cs
+++ b/AMFormsCST.Desktop/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using AMFormsCST.Desktop.Interfaces;
 using AMFormsCST.Desktop.Services;
 using AMFormsCST.Desktop.ViewModels;
 using AMFormsCST.Desktop.Views.Pages;
+using AMFormsCST.Desktop.Views.Pages.Links;
 using AMFormsCST.Desktop.Views.Pages.Tools;
 using System.Windows;
 using Wpf.Ui;
@@ -41,7 +42,8 @@ public partial class MainWindow : IWindow
         ViewModel.NavigationItems =
         [
             new NavigationViewItem("Dashboard", SymbolRegular.Home24, typeof(DashboardPage)),
-            new NavigationViewItem("Tools", SymbolRegular.Wrench24, typeof(ToolsPage))
+            new NavigationViewItem("Tools", SymbolRegular.Wrench24, typeof(ToolsPage)),
+            new NavigationViewItem("Links", SymbolRegular.Globe24, typeof(LinksPage))
         ];
 
         ViewModel.NavigationFooter =

--- a/AMFormsCST.Desktop/Models/LinkModel.cs
+++ b/AMFormsCST.Desktop/Models/LinkModel.cs
@@ -1,0 +1,8 @@
+namespace AMFormsCST.Desktop.Models
+{
+    public class LinkModel
+    {
+        public required string DisplayName { get; set; }
+        public required string Key { get; set; }
+    }
+}

--- a/AMFormsCST.Desktop/Services/DesignTimeDialogService.cs
+++ b/AMFormsCST.Desktop/Services/DesignTimeDialogService.cs
@@ -24,5 +24,9 @@ public class DesignTimeDialogService : IDialogService
 
     public string? ShowOpenFileDialog(string filter, string defaultDirectory)
     => "C:\\temp\\design_time_file.formgen";
-    
+
+    public IDialogService.DialogResult ShowDialog(string title, Page content)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/AMFormsCST.Desktop/Services/DesignTimeLinksService.cs
+++ b/AMFormsCST.Desktop/Services/DesignTimeLinksService.cs
@@ -1,0 +1,15 @@
+using AMFormsCST.Core.Interfaces;
+using System.Diagnostics;
+
+namespace AMFormsCST.Desktop.Services
+{
+    public class DesignTimeLinksService : ILinksService
+    {
+        public void OpenLink(string linkKey)
+        {
+            // In design time, we don't want to open actual links.
+            // We can write to the debug console to simulate the action.
+            Debug.WriteLine($"[DESIGN TIME] Attempted to open link with key: {linkKey}");
+        }
+    }
+}

--- a/AMFormsCST.Desktop/Services/DialogService.cs
+++ b/AMFormsCST.Desktop/Services/DialogService.cs
@@ -88,4 +88,13 @@ public class DialogService : IDialogService
         _logger?.LogInfo("No file selected.");
         return null;
     }
+
+    public IDialogService.DialogResult ShowDialog(string title, Page content)
+    {
+        _logger?.LogInfo($"ShowDialog called: Title='{title}'");
+        var dialog = new PageHostDialog(content, title, true);
+        dialog.ShowDialog();
+        _logger?.LogInfo($"Dialog closed: ConfirmSelected={dialog.ConfirmSelected}");
+        return dialog.ConfirmSelected ? IDialogService.DialogResult.Primary : IDialogService.DialogResult.Cancel;
+    }
 }

--- a/AMFormsCST.Desktop/Services/IDialogService.cs
+++ b/AMFormsCST.Desktop/Services/IDialogService.cs
@@ -5,6 +5,13 @@ namespace AMFormsCST.Desktop.Services
 {
     public interface IDialogService
     {
+        public enum DialogResult
+        {
+            Primary,
+            Secondary,
+            Cancel
+        }
+
         MessageBoxResult ShowMessageBox(string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon);
 
         (bool? DialogResult, string TemplateName, string TemplateDescription, string TemplateContent) ShowNewTemplateDialog(string? name = null, string? description = null, string? content = null);
@@ -13,5 +20,6 @@ namespace AMFormsCST.Desktop.Services
 
         string? ShowOpenFileDialog(string filter);
         string? ShowOpenFileDialog(string filter, string defaultDirectory);
+        DialogResult ShowDialog(string title, Page content);
     }
 }

--- a/AMFormsCST.Desktop/Services/LinksService.cs
+++ b/AMFormsCST.Desktop/Services/LinksService.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Diagnostics;
+using AMFormsCST.Core.Interfaces;
+
+namespace AMFormsCST.Desktop.Services
+{
+    public class LinksService : ILinksService
+    {
+        private readonly ILogService? _logger;
+
+        public LinksService(ILogService? logger = null)
+        {
+            _logger = logger;
+        }
+
+        public void OpenLink(string linkKey)
+        {
+            try
+            {
+                string path = linkKey switch
+                {
+                    "ADP" => "https://my.adp.com",
+                    "SalesForce" => "https://am.my.salesforce.com",
+                    "MyApps" => "https://myapps.microsoft.com",
+                    "ClientInfoReport" => "https://americamp.sharepoint.com/:x:/r/sites/Compliance-Public/Shared%20Documents/Call%20Center/Client%20Information%20Report.xlsm?d=w2f7b6a8f3c9c4d6a9b7f8e7d0b4a9a6b&csf=1&web=1&e=VvWw9T",
+                    "FormsTracker" => "https://americamp.sharepoint.com/sites/Compliance-Public/Lists/Formgen%20Request%20Tracker/AllItems.aspx",
+                    "Workday" => "https://wd5.myworkday.com/americamp/d/home.htmld",
+                    "CST" => $"{Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)}\\AmpsSupport\\CSTLoader.exe",
+                    "Formgen" => $"{Environment.GetFolderPath(Environment.SpecialFolder.Desktop)}\\NewFormGen.lnk",
+                    _ => string.Empty
+                };
+
+                if (string.IsNullOrEmpty(path)) return;
+
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = path,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError($"Failed to open link for {linkKey}.", ex);
+            }
+        }
+    }
+}

--- a/AMFormsCST.Desktop/ViewModels/Dialogs/AddLinkDialogViewModel.cs
+++ b/AMFormsCST.Desktop/ViewModels/Dialogs/AddLinkDialogViewModel.cs
@@ -1,0 +1,13 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AMFormsCST.Desktop.ViewModels.Dialogs
+{
+    public partial class AddLinkDialogViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private string _displayName = string.Empty;
+
+        [ObservableProperty]
+        private string _path = string.Empty;
+    }
+}

--- a/AMFormsCST.Desktop/ViewModels/Pages/Links/LinksViewModel.cs
+++ b/AMFormsCST.Desktop/ViewModels/Pages/Links/LinksViewModel.cs
@@ -1,0 +1,105 @@
+using AMFormsCST.Core.Interfaces;
+using AMFormsCST.Desktop.Models;
+using AMFormsCST.Desktop.Services;
+using AMFormsCST.Desktop.ViewModels.Dialogs;
+using AMFormsCST.Desktop.Views.Dialogs;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using Wpf.Ui.Abstractions.Controls;
+using Wpf.Ui.Controls;
+
+namespace AMFormsCST.Desktop.ViewModels.Pages.Links
+{
+    public partial class LinksViewModel : ObservableObject, INavigationAware
+    {
+        private readonly ILogService? _logger;
+        private readonly ILinksService _linksService;
+        private readonly IDialogService? _dialogService;
+
+        [ObservableProperty]
+        private ObservableCollection<LinkModel> _links = [];
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LinksViewModel"/> class for design-time purposes.
+        /// </summary>
+        public LinksViewModel() : this(new DesignTimeLinksService(), new DesignTimeDialogService())
+        {
+        }
+
+        public LinksViewModel(ILinksService linksService, IDialogService dialogService, ILogService? logger = null)
+        {
+            _linksService = linksService;
+            _dialogService = dialogService;
+            _logger = logger;
+
+            // Initialize with default links if the collection is empty
+            if (Links.Count == 0)
+            {
+                Links = new ObservableCollection<LinkModel>
+                {
+                    new() { DisplayName = "ADP", Key = "ADP" },
+                    new() { DisplayName = "SalesForce", Key = "SalesForce" },
+                    new() { DisplayName = "MyApps", Key = "MyApps" },
+                    new() { DisplayName = "Client Info Report", Key = "ClientInfoReport" },
+                    new() { DisplayName = "Forms Tracker", Key = "FormsTracker" },
+                    new() { DisplayName = "Workday", Key = "Workday" },
+                    new() { DisplayName = "CST", Key = "CST" },
+                    new() { DisplayName = "Formgen", Key = "Formgen" }
+                };
+            }
+        }
+
+        public void OnNavigatedTo()
+        {
+            _logger?.LogInfo("LinksViewModel navigated to.");
+        }
+
+        public void OnNavigatedFrom()
+        {
+            _logger?.LogInfo("LinksViewModel navigated from.");
+        }
+
+        [RelayCommand]
+        private void OnLinkClick(LinkModel? parameter)
+        {
+            if (parameter is null || string.IsNullOrEmpty(parameter.Key))
+            {
+                return;
+            }
+            _linksService.OpenLink(parameter.Key);
+        }
+
+        [RelayCommand]
+        private void OnAddLinkClick()
+        {
+            if (_dialogService is null) return;
+
+            var addLinkVm = new AddLinkDialogViewModel();
+            var addLinkPage = new AddLinkDialogPage(addLinkVm);
+
+            var result = _dialogService.ShowDialog("Add New Link", addLinkPage);
+
+            if (result == IDialogService.DialogResult.Primary)
+            {
+                if (!string.IsNullOrWhiteSpace(addLinkVm.DisplayName) && !string.IsNullOrWhiteSpace(addLinkVm.Path))
+                {
+                    var newLink = new LinkModel { DisplayName = addLinkVm.DisplayName, Key = addLinkVm.Path };
+                    Links.Add(newLink);
+                    _logger?.LogInfo($"New link added: {newLink.DisplayName}");
+                }
+            }
+        }
+        public Task OnNavigatedToAsync()
+        {
+            _logger?.LogInfo("LinksViewModel navigated to asynchronously.");
+            return Task.CompletedTask;
+        }
+
+        public Task OnNavigatedFromAsync()
+        {
+            _logger?.LogInfo("LinksViewModel navigated from asynchronously.");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/AMFormsCST.Desktop/Views/Dialogs/AddLinkDialogPage.xaml
+++ b/AMFormsCST.Desktop/Views/Dialogs/AddLinkDialogPage.xaml
@@ -1,0 +1,24 @@
+<Page
+    x:Class="AMFormsCST.Desktop.Views.Dialogs.AddLinkDialogPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:AMFormsCST.Desktop.Views.Dialogs"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:viewmodels="clr-namespace:AMFormsCST.Desktop.ViewModels.Dialogs"
+    Title="AddLinkDialogPage"
+    d:DataContext="{d:DesignInstance Type=viewmodels:AddLinkDialogViewModel}"
+    d:DesignHeight="200"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+    <Grid Margin="10">
+        <StackPanel>
+            <Label Margin="0,0,0,5" Content="Display Name" />
+            <ui:TextBox Margin="0,0,0,10" Text="{Binding DisplayName, UpdateSourceTrigger=PropertyChanged}" />
+
+            <Label Margin="0,0,0,5" Content="URL or File Path" />
+            <ui:TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}" />
+        </StackPanel>
+    </Grid>
+</Page>

--- a/AMFormsCST.Desktop/Views/Dialogs/AddLinkDialogPage.xaml.cs
+++ b/AMFormsCST.Desktop/Views/Dialogs/AddLinkDialogPage.xaml.cs
@@ -1,0 +1,20 @@
+using AMFormsCST.Desktop.ViewModels.Dialogs;
+using System.Windows.Controls;
+
+namespace AMFormsCST.Desktop.Views.Dialogs
+{
+    /// <summary>
+    /// Interaction logic for AddLinkDialogPage.xaml
+    /// </summary>
+    public partial class AddLinkDialogPage : Page
+    {
+        public AddLinkDialogViewModel ViewModel { get; }
+
+        public AddLinkDialogPage(AddLinkDialogViewModel viewModel)
+        {
+            ViewModel = viewModel;
+            DataContext = ViewModel;
+            InitializeComponent();
+        }
+    }
+}

--- a/AMFormsCST.Desktop/Views/Pages/Links/LinksPage.xaml
+++ b/AMFormsCST.Desktop/Views/Pages/Links/LinksPage.xaml
@@ -1,0 +1,55 @@
+<Page
+    x:Class="AMFormsCST.Desktop.Views.Pages.Links.LinksPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:AMFormsCST.Desktop.ViewModels.Pages.Links"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="clr-namespace:AMFormsCST.Desktop.Models"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="LinksPage"
+    d:DataContext="{d:DesignInstance local:LinksViewModel,
+                                     IsDesignTimeCreatable=False}"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    mc:Ignorable="d">
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding Links}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel HorizontalAlignment="Left" VerticalAlignment="Top" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type models:LinkModel}">
+                        <ui:Button
+                            Margin="5"
+                            Appearance="Primary"
+                            Command="{Binding DataContext.LinkClickCommand, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                            CommandParameter="{Binding}"
+                            Content="{Binding DisplayName}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+
+        <!--<ui:Button
+            Grid.Row="1"
+            Margin="0,10,0,0"
+            HorizontalAlignment="Right"
+            Appearance="Secondary"
+            Command="{Binding AddLinkClickCommand}"
+            Content="Add New Link"
+            Icon="{ui:SymbolIcon Add24}" />-->
+    </Grid>
+</Page>

--- a/AMFormsCST.Desktop/Views/Pages/Links/LinksPage.xaml.cs
+++ b/AMFormsCST.Desktop/Views/Pages/Links/LinksPage.xaml.cs
@@ -1,0 +1,77 @@
+using AMFormsCST.Core.Interfaces;
+using AMFormsCST.Desktop.ViewModels.Pages.Links;
+using System.Windows;
+using Wpf.Ui;
+using Wpf.Ui.Abstractions.Controls;
+using Wpf.Ui.Controls;
+
+namespace AMFormsCST.Desktop.Views.Pages.Links
+{
+    /// <summary>
+    /// Interaction logic for LinksPage.xaml
+    /// </summary>
+    public partial class LinksPage : INavigableView<LinksViewModel>
+    {
+        private readonly INavigationService? _navigationService;
+        private readonly ILogService? _logger;
+
+        public LinksViewModel ViewModel { get; }
+
+        public LinksPage(LinksViewModel viewModel, INavigationService navigationService, ILogService? logger = null)
+        {
+            ViewModel = viewModel;
+            DataContext = ViewModel;
+            _navigationService = navigationService;
+            _logger = logger;
+            InitializeComponent();
+            Loaded += HandleLoaded;
+            Unloaded += HandleUnloaded;
+            _logger?.LogInfo("LinksPage initialized.");
+        }
+
+        private void HandleLoaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_navigationService is null) return;
+                INavigationView? navigationControl = _navigationService.GetNavigationControl();
+                if (
+                    navigationControl?.BreadcrumbBar != null
+                    && navigationControl.BreadcrumbBar.Visibility != Visibility.Visible
+                )
+                {
+                    navigationControl.BreadcrumbBar.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                }
+                _logger?.LogInfo("LinksPage loaded. BreadcrumbBar set to Visible.");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError("Error in LinksPage HandleLoaded.", ex);
+            }
+        }
+
+        private void HandleUnloaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_navigationService is null) return;
+                INavigationView? navigationControl = _navigationService.GetNavigationControl();
+                if (
+                    navigationControl?.BreadcrumbBar != null
+                    && navigationControl.BreadcrumbBar.Visibility != Visibility.Collapsed
+                )
+                {
+                    navigationControl.BreadcrumbBar.SetCurrentValue(VisibilityProperty, Visibility.Collapsed);
+                }
+
+                Loaded -= HandleLoaded;
+                Unloaded -= HandleUnloaded;
+                _logger?.LogInfo("LinksPage unloaded. BreadcrumbBar set to Collapsed.");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError("Error in LinksPage HandleUnloaded.", ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduced a new `LinksPage` feature with navigation, services, and view models to manage and open predefined links.

- Updated `App.xaml.cs` to register `LinksPage`, `LinksViewModel`, and `ILinksService` in the DI container.
- Added `LinksService` to handle link opening functionality and `DesignTimeLinksService` for design-time support.
- Created `LinkModel` to represent links and `AddLinkDialogViewModel` for adding new links.
- Implemented `AddLinkDialogPage` for user input and integrated it with `DialogService`.
- Updated `MainWindow.xaml.cs` to include `LinksPage` in the navigation menu.
- Enhanced `IDialogService` with a new `ShowDialog` method and `DialogResult` enum.
- Added logging across `LinksPage`, `LinksViewModel`, and `DialogService` for better traceability.
- Updated project file to exclude `Releases` folder from compilation.

This commit lays the groundwork for managing and interacting with external links in the application.