### PR TITLE
Add navigation commands and enhance collection handling

### DIFF
--- a/AMFormsCST.Desktop/AMFormsCST.Desktop.csproj
+++ b/AMFormsCST.Desktop/AMFormsCST.Desktop.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Assets\Solera_Logo_Symbol_Only.ico</ApplicationIcon>
-    <AssemblyVersion>2.2.5</AssemblyVersion>
+    <AssemblyVersion>2.3.0</AssemblyVersion>
     <FileVersion>$(assemblyversion)</FileVersion>
     <Version>$(assemblyversion)</Version>
   </PropertyGroup>

--- a/AMFormsCST.Desktop/Controls/ManagedObservableCollectionSelector.xaml
+++ b/AMFormsCST.Desktop/Controls/ManagedObservableCollectionSelector.xaml
@@ -20,7 +20,17 @@
     </UserControl.Resources>
 
     <Grid HorizontalAlignment="Stretch" Margin="0,0,0,0">
-        <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Visible">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <Button Grid.Column="0" Command="{Binding PreviousCommand, ElementName=RadioButtonControl}" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" VerticalAlignment="Center">
+            <TextBlock Text="&#xE76B;" FontFamily="Segoe MDL2 Assets"  Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+        </Button>
+
+        <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Visible">
             <ItemsControl ItemsSource="{Binding ItemsSource, ElementName=RadioButtonControl}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
@@ -117,5 +127,9 @@
                 </ItemsControl.Resources>
             </ItemsControl>
         </ScrollViewer>
+
+        <Button Grid.Column="2" Command="{Binding NextCommand, ElementName=RadioButtonControl}" Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" VerticalAlignment="Center">
+            <TextBlock Text="&#xE76C;" FontFamily="Segoe MDL2 Assets"  Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+        </Button>
     </Grid>
 </UserControl>

--- a/AMFormsCST.Desktop/Controls/ManagedObservableCollectionSelector.xaml.cs
+++ b/AMFormsCST.Desktop/Controls/ManagedObservableCollectionSelector.xaml.cs
@@ -112,4 +112,22 @@ public partial class ManagedObservableCollectionSelector : UserControl
         get { return (ICommand)GetValue(DeleteCommandProperty); }
         set { SetValue(DeleteCommandProperty, value); }
     }
+
+    public static readonly DependencyProperty PreviousCommandProperty =
+        DependencyProperty.Register(nameof(PreviousCommand), typeof(ICommand), typeof(ManagedObservableCollectionSelector), new PropertyMetadata(null));
+
+    public ICommand PreviousCommand
+    {
+        get { return (ICommand)GetValue(PreviousCommandProperty); }
+        set { SetValue(PreviousCommandProperty, value); }
+    }
+
+    public static readonly DependencyProperty NextCommandProperty =
+        DependencyProperty.Register(nameof(NextCommand), typeof(ICommand), typeof(ManagedObservableCollectionSelector), new PropertyMetadata(null));
+
+    public ICommand NextCommand
+    {
+        get { return (ICommand)GetValue(NextCommandProperty); }
+        set { SetValue(NextCommandProperty, value); }
+    }
 }

--- a/AMFormsCST.Desktop/Models/Notebook/Dealer.cs
+++ b/AMFormsCST.Desktop/Models/Notebook/Dealer.cs
@@ -130,6 +130,7 @@ namespace AMFormsCST.Desktop.Models
                     c.PropertyChanged -= OnCompanyPropertyChanged;
 
             UpdateCore();
+            Parent?.Parent?.NotifyCompanyNavigationChanged();
             _logger?.LogDebug("Companies collection changed.");
         }
 

--- a/AMFormsCST.Desktop/Models/Notebook/Form.cs
+++ b/AMFormsCST.Desktop/Models/Notebook/Form.cs
@@ -165,6 +165,7 @@ public partial class Form : ManagedObservableCollectionItem
             foreach (TestDeal td in e.OldItems)
                 td.PropertyChanged -= OnTestDealPropertyChanged;
         UpdateCore();
+        Parent?.Parent?.NotifyTestDealNavigationChanged();
         _logger?.LogDebug("TestDeals collection changed.");
     }
 

--- a/AMFormsCST.Desktop/Models/Notebook/NoteModel.cs
+++ b/AMFormsCST.Desktop/Models/Notebook/NoteModel.cs
@@ -158,6 +158,7 @@ public partial class NoteModel : ManagedObservableCollectionItem
             (d) => d.PropertyChanged += OnDealerPropertyChanged
         );
         Dealers.CollectionChanged += Dealers_CollectionChanged;
+        Dealers.PropertyChanged += OnDealerPropertyChanged;
         Dealers.FirstOrDefault()?.Select();
     }
     private void InitContacts(string phoneExtensionDelimiter)
@@ -177,6 +178,7 @@ public partial class NoteModel : ManagedObservableCollectionItem
             (c) => c.PropertyChanged += OnContactPropertyChanged
         );
         Contacts.CollectionChanged += Contacts_CollectionChanged;
+        Contacts.PropertyChanged += OnContactPropertyChanged;
         Contacts.FirstOrDefault()?.Select();
     }
     private void InitForms()
@@ -196,6 +198,7 @@ public partial class NoteModel : ManagedObservableCollectionItem
             (f) => f.PropertyChanged += OnFormPropertyChanged
         );
         Forms.CollectionChanged += Forms_CollectionChanged;
+        Forms.PropertyChanged += OnFormPropertyChanged;
         Forms.FirstOrDefault()?.Select();
     }
 
@@ -248,6 +251,7 @@ public partial class NoteModel : ManagedObservableCollectionItem
             foreach (Dealer d in e.OldItems)
                 d.PropertyChanged -= OnDealerPropertyChanged;
         UpdateCore();
+        Parent?.NotifyDealerNavigationChanged();
         _logger?.LogDebug("Dealers collection changed.");
     }
     private void Contacts_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -263,6 +267,7 @@ public partial class NoteModel : ManagedObservableCollectionItem
             foreach (Contact c in e.OldItems)
                 c.PropertyChanged -= OnContactPropertyChanged;
         UpdateCore();
+        Parent?.NotifyContactNavigationChanged();
         _logger?.LogDebug("Contacts collection changed.");
     }
     private void Forms_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -280,6 +285,7 @@ public partial class NoteModel : ManagedObservableCollectionItem
                 f.PropertyChanged -= OnFormPropertyChanged;
 
         UpdateCore();
+        Parent?.NotifyFormNavigationChanged();
         _logger?.LogDebug("Forms collection changed.");
     }
 

--- a/AMFormsCST.Desktop/Views/Pages/DashboardPage.xaml
+++ b/AMFormsCST.Desktop/Views/Pages/DashboardPage.xaml
@@ -57,9 +57,11 @@
                              ContentBindingPath="CaseNumber"
                              ContentFallbackValue="Enter a Case Number..."
                              GroupName="CaseNumbers"
-                                 RefreshTrigger="{Binding UiRefreshCounter}"
-                                 DeleteCommand="{Binding DeleteItemClickedCommand}"
-                                                        ToolTip="Select, add, or delete a case note."/>
+                             RefreshTrigger="{Binding UiRefreshCounter}"
+                             DeleteCommand="{Binding DeleteItemClickedCommand}"
+                             ToolTip="Select, add, or delete a case note."
+                             NextCommand="{Binding SelectNextNoteCommand}"
+                             PreviousCommand="{Binding SelectPreviousNoteCommand}"/>
 
 
         <Grid  Grid.Row="1" Grid.Column="1" VerticalAlignment="Stretch">
@@ -110,7 +112,9 @@
                                                          ContentFallbackValue="Enter a Dealership Name..."
                                                          GroupName="DealerNames"
                                  RefreshTrigger="{Binding UiRefreshCounter}"
-                                 DeleteCommand="{Binding DeleteItemClickedCommand}" Margin="0,0,0,5" Grid.ColumnSpan="3" ToolTip="Select, add, or delete a dealership for this note."/>
+                                 DeleteCommand="{Binding DeleteItemClickedCommand}" Margin="0,0,0,5" Grid.ColumnSpan="3" ToolTip="Select, add, or delete a dealership for this note."
+                                                         NextCommand="{Binding SelectNextDealerCommand}"
+                                                         PreviousCommand="{Binding SelectPreviousDealerCommand}"/>
 
             <controls:ManagedObservableCollectionSelector ItemsSource="{Binding SelectedNote.SelectedDealer.Companies}" 
                                                          RadioButtonCommand="{Binding CompanyClickedCommand}" 
@@ -119,7 +123,9 @@
                                                          ContentFallbackValue="Enter a Company Number..."
                                                          GroupName="CompanyNames"
                                  RefreshTrigger="{Binding UiRefreshCounter}"
-                                 DeleteCommand="{Binding DeleteItemClickedCommand}" Grid.ColumnSpan="3" Grid.Row="1" Margin="0,0,0,5" ToolTip="Select, add, or delete a company for the selected dealership."/>
+                                 DeleteCommand="{Binding DeleteItemClickedCommand}" Grid.ColumnSpan="3" Grid.Row="1" Margin="0,0,0,5" ToolTip="Select, add, or delete a company for the selected dealership."
+                                                         NextCommand="{Binding SelectNextCompanyCommand}"
+                                                         PreviousCommand="{Binding SelectPreviousCompanyCommand}"/>
 
             <Label Content="Dealer/Group Name: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Row="2"/>
             <ui:TextBox Text="{Binding SelectedNote.SelectedDealer.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
@@ -173,7 +179,9 @@
                                          ContentFallbackValue="Enter a Form Name..."
                                          GroupName="FormNames"
                  RefreshTrigger="{Binding UiRefreshCounter}"
-                 DeleteCommand="{Binding DeleteItemClickedCommand}" Margin="0,0,0,5" Grid.ColumnSpan="2" ToolTip="Select, add, or delete a form for this note."/>
+                 DeleteCommand="{Binding DeleteItemClickedCommand}" Margin="0,0,0,5" Grid.ColumnSpan="2" ToolTip="Select, add, or delete a form for this note."
+                                         NextCommand="{Binding SelectNextFormCommand}"
+                                         PreviousCommand="{Binding SelectPreviousFormCommand}"/>
 
             <controls:ManagedObservableCollectionSelector ItemsSource="{Binding SelectedNote.SelectedForm.TestDeals}" 
                                          RadioButtonCommand="{Binding DealClickedCommand}" 
@@ -182,7 +190,9 @@
                                          ContentFallbackValue="Enter a Deal Number..."
                                          GroupName="TestDeals"
                  RefreshTrigger="{Binding UiRefreshCounter}"
-                 DeleteCommand="{Binding DeleteItemClickedCommand}" Grid.ColumnSpan="2" Grid.Row="1" Margin="0,0,0,5" ToolTip="Select, add, or delete a test deal for the selected form."/>
+                 DeleteCommand="{Binding DeleteItemClickedCommand}" Grid.ColumnSpan="2" Grid.Row="1" Margin="0,0,0,5" ToolTip="Select, add, or delete a test deal for the selected form."
+                                         NextCommand="{Binding SelectNextTestDealCommand}"
+                                         PreviousCommand="{Binding SelectPreviousTestDealCommand}"/>
 
             <Label Content="Name: " VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="2" Grid.Column="0"/>
             <ui:TextBox Text="{Binding SelectedNote.SelectedForm.Name, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" 
@@ -239,8 +249,13 @@
                                      ContentBindingPath="Name"
                                      ContentFallbackValue="Enter a Contact Name..."
                                      GroupName="ContactNames"
-             RefreshTrigger="{Binding UiRefreshCounter}"
-             DeleteCommand="{Binding DeleteItemClickedCommand}" Grid.ColumnSpan="2" Margin="0,0,0,5" ToolTip="Select, add, or delete a contact for this note."/>
+                                     RefreshTrigger="{Binding UiRefreshCounter}"
+                                     DeleteCommand="{Binding DeleteItemClickedCommand}" 
+                                     Grid.ColumnSpan="2" 
+                                     Margin="0,0,0,5" 
+                                     ToolTip="Select, add, or delete a contact for this note."
+                                     NextCommand="{Binding SelectNextContactCommand}"
+                                     PreviousCommand="{Binding SelectPreviousContactCommand}"/>
 
             <Label Content="Name: " VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="1"/>
             <ui:TextBox Text="{Binding SelectedNote.SelectedContact.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 

--- a/AMFormsCST.Test/Desktop/Controls/ManagedObservableCollectionSelectorTests.cs
+++ b/AMFormsCST.Test/Desktop/Controls/ManagedObservableCollectionSelectorTests.cs
@@ -116,4 +116,32 @@ public class ManagedObservableCollectionSelectorTests
         // Assert
         Assert.Same(commandMock.Object, control.DeleteCommand);
     }
+
+    [WpfFact]
+    public void PreviousCommand_Property_SetAndGet_Works()
+    {
+        // Arrange
+        var control = new ManagedObservableCollectionSelector();
+        var commandMock = new Mock<ICommand>();
+
+        // Act
+        control.PreviousCommand = commandMock.Object;
+
+        // Assert
+        Assert.Same(commandMock.Object, control.PreviousCommand);
+    }
+
+    [WpfFact]
+    public void NextCommand_Property_SetAndGet_Works()
+    {
+        // Arrange
+        var control = new ManagedObservableCollectionSelector();
+        var commandMock = new Mock<ICommand>();
+
+        // Act
+        control.NextCommand = commandMock.Object;
+
+        // Assert
+        Assert.Same(commandMock.Object, control.NextCommand);
+    }
 }


### PR DESCRIPTION
Enhanced `ManagedObservableCollectionSelector` with `NextCommand` and `PreviousCommand` for improved navigation. Updated XAML to include navigation buttons and bindings.

Refactored `DashboardViewModel` to handle navigation state updates with `Notify...NavigationChanged()` methods and added commands for navigating between notes, dealers, companies, contacts, forms, and test deals.

Introduced unit tests for navigation commands. Improved logging and refactored property change handlers for better readability. Updated `AssemblyVersion` to 2.3.0.