### PR TITLE
Add rich text support and enhance template handling

### DIFF
--- a/AMFormsCST.Core/AMFormsCST.Core.csproj
+++ b/AMFormsCST.Core/AMFormsCST.Core.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="PresentationFramework" Version="4.6.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="System.Drawing.Common" Version="*" />
   </ItemGroup>

--- a/AMFormsCST.Core/Converters/TextTemplateJsonConverter.cs
+++ b/AMFormsCST.Core/Converters/TextTemplateJsonConverter.cs
@@ -1,0 +1,94 @@
+using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Windows.Documents;
+using System.Windows.Markup;
+
+namespace AMFormsCST.Core.Converters;
+
+public class TextTemplateJsonConverter : JsonConverter<TextTemplate>
+{
+    public override TextTemplate? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected StartObject token");
+        }
+
+        Guid id = default;
+        string name = string.Empty;
+        string description = string.Empty;
+        FlowDocument text = new();
+        TextTemplate.TemplateType type = default;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return new TextTemplate(id, name, description, text, type);
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected PropertyName token");
+            }
+
+            var propertyName = reader.GetString();
+            reader.Read(); // Move to the property value
+
+            switch (propertyName?.ToLowerInvariant())
+            {
+                case "id":
+                    id = reader.GetGuid();
+                    break;
+                case "name":
+                    name = reader.GetString() ?? string.Empty;
+                    break;
+                case "description":
+                    description = reader.GetString() ?? string.Empty;
+                    break;
+                case "type":
+                    // Handle both string and integer enum values
+                    if (reader.TokenType == JsonTokenType.String)
+                        Enum.TryParse(reader.GetString(), true, out type);
+                    else if (reader.TokenType == JsonTokenType.Number)
+                        type = (TextTemplate.TemplateType)reader.GetInt32();
+                    break;
+                case "text":
+                    var textValue = reader.GetString() ?? string.Empty;
+                    try
+                    {
+                        // Try to parse as XAML (new format)
+                        text = (FlowDocument)XamlReader.Parse(textValue);
+                    }
+                    catch (XamlParseException)
+                    {
+                        // If it fails, treat it as plain text (old format)
+                        text = new FlowDocument(new Paragraph(new Run(textValue)));
+                    }
+                    break;
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        throw new JsonException("Unexpected end of JSON.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TextTemplate value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("id", value.Id);
+        writer.WriteString("name", value.Name);
+        writer.WriteString("description", value.Description);
+        writer.WriteNumber("type", (int)value.Type);
+
+        // Serialize FlowDocument to a XAML string
+        var xamlText = XamlWriter.Save(value.Text);
+        writer.WriteString("text", xamlText);
+
+        writer.WriteEndObject();
+    }
+}

--- a/AMFormsCST.Core/IO.cs
+++ b/AMFormsCST.Core/IO.cs
@@ -1,4 +1,5 @@
-﻿using AMFormsCST.Core.Helpers;
+﻿using AMFormsCST.Core.Converters;
+using AMFormsCST.Core.Helpers;
 using AMFormsCST.Core.Interfaces;
 using AMFormsCST.Core.Interfaces.Notebook;
 using AMFormsCST.Core.Interfaces.UserSettings;
@@ -8,6 +9,7 @@ using System.Text.Json;
 using System.Xml;
 
 namespace AMFormsCST.Core;
+
 public static class IO
 {
     private static readonly string _appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -62,6 +64,7 @@ public static class IO
         _jsonOptions.Converters.Add(new SelectableListJsonConverter<IForm>());
         _jsonOptions.Converters.Add(new SelectableListJsonConverter<ITestDeal>());
         _jsonOptions.Converters.Add(new SelectableListJsonConverter<INote>());
+        _jsonOptions.Converters.Add(new TextTemplateJsonConverter());
         Logger?.LogInfo("IO JSON serializer configured.");
     }
 

--- a/AMFormsCST.Core/Interfaces/Notebook/IForm.cs
+++ b/AMFormsCST.Core/Interfaces/Notebook/IForm.cs
@@ -10,5 +10,12 @@ public interface IForm : INotebookItem<IForm>
     string Name { get; set; }
     bool Notable { get; set; }
     string Notes { get; set; }
+    FormFormat Format { get; set; }
     SelectableList<ITestDeal> TestDeals { get; set; }
+
+    public enum FormFormat
+    {
+        LegacyImpact,
+        Pdf
+    }
 }

--- a/AMFormsCST.Core/Types/BestPractices/TextTemplates/Models/TextTemplate.cs
+++ b/AMFormsCST.Core/Types/BestPractices/TextTemplates/Models/TextTemplate.cs
@@ -1,6 +1,7 @@
 ﻿using AMFormsCST.Core.Interfaces;
 using AMFormsCST.Core.Interfaces.BestPractices;
 using System.Text.Json.Serialization;
+using System.Windows.Documents;
 
 namespace AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 public class TextTemplate : IEquatable<TextTemplate>
@@ -9,7 +10,7 @@ public class TextTemplate : IEquatable<TextTemplate>
     public Guid Id { get; private set; }// Default to empty GUID for new templates
     public string Name { get; set; }
     public string Description { get; set; }
-    public string Text { get; set; }
+    public FlowDocument Text { get; set; }
     public TemplateType Type { get; set; } 
     public enum TemplateType
     {
@@ -19,7 +20,7 @@ public class TextTemplate : IEquatable<TextTemplate>
         Email,
         Other
     }
-    public TextTemplate(string name, string description, string text, TemplateType type)
+    public TextTemplate(string name, string description, FlowDocument text, TemplateType type)
     {
         Id = Guid.NewGuid(); // Or pass in an existing ID for editing
         Name = name;
@@ -28,7 +29,7 @@ public class TextTemplate : IEquatable<TextTemplate>
         Type = type;
     }
     [JsonConstructor]
-    public TextTemplate(Guid id, string name, string description, string text, TemplateType type)
+    public TextTemplate(Guid id, string name, string description, FlowDocument text, TemplateType type)
     {
         Id = id;
         Name = name;
@@ -47,8 +48,8 @@ public class TextTemplate : IEquatable<TextTemplate>
         foreach (var variable in supportTool.Settings.UserSettings.Organization.Variables)
         {
             if (Text is not null && 
-                (Text.Contains(variable.ProperName, StringComparison.InvariantCultureIgnoreCase) ||
-                Text.Contains(variable.Prefix + variable.Name, StringComparison.InvariantCultureIgnoreCase)))
+                (GetFlowDocumentPlainText(Text).Contains(variable.ProperName, StringComparison.InvariantCultureIgnoreCase) ||
+                GetFlowDocumentPlainText(Text).Contains(variable.Prefix + variable.Name, StringComparison.InvariantCultureIgnoreCase)))
             {
                 variables.Add(variable);
             }
@@ -143,6 +144,17 @@ public class TextTemplate : IEquatable<TextTemplate>
         }
 
         return lowestIndex;
+    }
+    public static string GetFlowDocumentPlainText(FlowDocument document)
+    {
+        // Create a TextRange from the beginning (ContentStart) to the end (ContentEnd) of the document.
+        TextRange textRange = new TextRange(
+            document.ContentStart,
+            document.ContentEnd
+        );
+
+        // The Text property of the TextRange object returns the plain text content as a string.
+        return textRange.Text;
     }
 }
 

--- a/AMFormsCST.Core/Types/Notebook/Form.cs
+++ b/AMFormsCST.Core/Types/Notebook/Form.cs
@@ -17,6 +17,8 @@ public class Form : IForm
     public bool Notable { get; set; } = true;
     public Guid Id => _id;
 
+    public IForm.FormFormat Format { get; set; }
+
     public Form() : this(null) { }
     public Form(ILogService? logger)
     {

--- a/AMFormsCST.Core/Types/UserSettings/AutomateFormsOrgVariables.cs
+++ b/AMFormsCST.Core/Types/UserSettings/AutomateFormsOrgVariables.cs
@@ -4,6 +4,7 @@ using AMFormsCST.Core.Interfaces.Utils;
 using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 using AMFormsCST.Core.Interfaces;
 using System.Text.Json.Serialization;
+using static AMFormsCST.Core.Interfaces.Notebook.IForm;
 
 namespace AMFormsCST.Core.Types.UserSettings;
 public class AutomateFormsOrgVariables : IOrgVariables
@@ -67,15 +68,15 @@ public class AutomateFormsOrgVariables : IOrgVariables
         }
 
         var variables = new List<ITextTemplateVariable>
-        { 
+        {
             new TextTemplateVariable(
              properName: "SelectedDealer:ServerID",
              name: "serverid",
              prefix: "selecteddealer:",
              description: "Server ID#",
              aliases: ["server", "serv", "code", "id"],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Dealers.SelectedItem?.ServerCode 
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Dealers.SelectedItem?.ServerCode
              ?? string.Empty
             ),
             new TextTemplateVariable(
@@ -84,8 +85,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectedcompany:",
              description: "Company#(s)",
              aliases: ["code"],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Dealers.SelectedItem?.Companies.SelectedItem?.CompanyCode 
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Dealers.SelectedItem?.Companies.SelectedItem?.CompanyCode
              ?? string.Empty
             ),
             new TextTemplateVariable(
@@ -94,8 +95,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selecteddealer:",
              description: "Dealership Name",
              aliases: [],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Dealers.SelectedItem?.Companies.SelectedItem?.Name 
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Dealers.SelectedItem?.Companies.SelectedItem?.Name
              ?? string.Empty
             ),
             new TextTemplateVariable(
@@ -104,8 +105,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectedcontact:",
              description: "Contact Name",
              aliases: [],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Contacts.SelectedItem?.Name 
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Contacts.SelectedItem?.Name
              ?? string.Empty
             ),
             new TextTemplateVariable(
@@ -114,8 +115,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectedcontact:",
              description: "E-Mail Address",
              aliases: ["email"],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Contacts.SelectedItem?.Email 
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Contacts.SelectedItem?.Email
              ?? string.Empty
             ),
             new TextTemplateVariable(
@@ -124,8 +125,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectedcontact:",
              description: "Phone#",
              aliases: [],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Contacts.SelectedItem?.Phone 
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Contacts.SelectedItem?.Phone
              ?? string.Empty
             ),
             new TextTemplateVariable(
@@ -134,9 +135,10 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectednote:",
              description: "Notes",
              aliases: [],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.NotesText 
-             ?? string.Empty
+             getValue: () =>
+             !string.IsNullOrWhiteSpace(_supportToolFactory()?.Notebook.Notes.SelectedItem?.NotesText) 
+                ? _supportToolFactory()!.Notebook.Notes.SelectedItem!.NotesText
+                : string.Empty
             ),
             new TextTemplateVariable(
              properName: "SelectedNote:CaseNumber",
@@ -144,8 +146,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectednote:",
              description: "Case#",
              aliases: ["caseno", "case"],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.CaseText 
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.CaseText
              ?? string.Empty
             ),
             new TextTemplateVariable(
@@ -154,8 +156,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectednote:",
              description: "All Forms",
              aliases: ["form"],
-             getValue: () => 
-             ">" + 
+             getValue: () =>
+             ">" +
              string.Join("\n>", _supportToolFactory()?.Notebook.Notes.SelectedItem?
                 .Forms.Where(f => !string.IsNullOrEmpty(f.Name)).Select(f => f.Name) ?? [])
             ),
@@ -165,8 +167,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectednote:",
              description: "Notable Forms",
              aliases: ["notable"],
-             getValue: () => 
-             ">" + 
+             getValue: () =>
+             ">" +
              string.Join("\n>", _supportToolFactory()?.Notebook.Notes.SelectedItem?
                 .Forms.Where(f => f.Notable).Where(f => !string.IsNullOrEmpty(f.Name)).Select(f => f.Name) ?? [])
             ),
@@ -190,7 +192,7 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "ammail:",
              description: "AutoMate Forms Mailing Address",
              aliases: ["all", "full", "mailingaddress", "mailto"],
-             getValue: () => 
+             getValue: () =>
              LooseVariables.TryGetValue("AMMailingAddress", out var address) ? address : string.Empty
             ),
             new TextTemplateVariable(
@@ -199,7 +201,7 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "ammail:",
              description: "AutoMate Forms Mailing Address - Name",
              aliases: [],
-             getValue: () => 
+             getValue: () =>
              LooseVariables.TryGetValue("AMMailingName", out var address) ? address : string.Empty
             ),
             new TextTemplateVariable(
@@ -208,7 +210,7 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "ammail:",
              description: "AutoMate Forms Mailing Address - Street Address",
              aliases: ["street", "line1"],
-             getValue: () => 
+             getValue: () =>
              LooseVariables.TryGetValue("AMStreetAddress", out var address) ? address : string.Empty
             ),
             new TextTemplateVariable(
@@ -217,7 +219,7 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "ammail:",
              description: "AutoMate Forms Mailing Address - City",
              aliases: [],
-             getValue: () => 
+             getValue: () =>
              LooseVariables.TryGetValue("AMCity", out var address) ? address : string.Empty
             ),
             new TextTemplateVariable(
@@ -226,7 +228,7 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "ammail:",
              description: "AutoMate Forms Mailing Address - State",
              aliases: [],
-             getValue: () => 
+             getValue: () =>
              LooseVariables.TryGetValue("AMState", out var address) ? address : string.Empty
             ),
             new TextTemplateVariable(
@@ -235,7 +237,7 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "ammail:",
              description: "AutoMate Forms Mailing Address - Zip Code",
              aliases: ["postalcode", "zip"],
-             getValue: () => 
+             getValue: () =>
              LooseVariables.TryGetValue("AMZip", out var address) ? address : string.Empty
             ),
             new TextTemplateVariable(
@@ -244,7 +246,7 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "ammail:",
              description: "AutoMate Forms Mailing Address - City, State Zip",
              aliases: ["csz", "line2"],
-             getValue: () => 
+             getValue: () =>
              LooseVariables.TryGetValue("AMCityStateZip", out var address) ? address : string.Empty
             ),
             new TextTemplateVariable(
@@ -253,8 +255,8 @@ public class AutomateFormsOrgVariables : IOrgVariables
              prefix: "selectedtestdeal:",
              description: "Test Deal#",
              aliases: ["dealno", "deal"],
-             getValue: () => 
-             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Forms.SelectedItem?.TestDeals.SelectedItem?.DealNumber 
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Forms.SelectedItem?.TestDeals.SelectedItem?.DealNumber
              ?? string.Empty
             ),
             new TextTemplateVariable(
@@ -285,7 +287,16 @@ public class AutomateFormsOrgVariables : IOrgVariables
              aliases: [],
              getValue: () =>
              string.Join("\n\n", _supportToolFactory()?.Notebook.Notes.SelectedItem?
-                .Forms.Where(f => f.Notable).Where(f => !string.IsNullOrEmpty(f.Name)).Select(f => "Name: " + f.Name + "\nNotes: " + f.Notes) ?? [])
+                .Forms.Where(f => f.Notable).Where(f => !string.IsNullOrEmpty(f.Name)).Select(f => "Name: " + f.Name +"\nFormat: " + f.Format.ToString() + "\nTest Deals: " + string.Join(", ", f.TestDeals.Select(td => td.DealNumber)) + "\nNotes: " + f.Notes) ?? [])
+            ),
+            new TextTemplateVariable(
+             properName: "SelectedForm:Type",
+             name: "formtype",
+             prefix: "selectedform:",
+             description: "Selected form type",
+             aliases: [],
+             getValue: () =>
+             _supportToolFactory()?.Notebook.Notes.SelectedItem?.Forms.SelectedItem?.Format.ToString() ?? FormFormat.Pdf.ToString()
             ),
             new TextTemplateVariable(
              properName: "User:Input",

--- a/AMFormsCST.Core/Utils/BestPracticeEnforcer.cs
+++ b/AMFormsCST.Core/Utils/BestPracticeEnforcer.cs
@@ -28,7 +28,7 @@ public class BestPracticeEnforcer : IBestPracticeEnforcer
         try
         {
             ArgumentNullException.ThrowIfNull(template);
-            if (string.IsNullOrWhiteSpace(template.Text)) throw new ArgumentException("Template text cannot be null or whitespace.", nameof(template));
+            if (string.IsNullOrWhiteSpace(TextTemplate.GetFlowDocumentPlainText(template.Text))) throw new ArgumentException("Template text cannot be null or whitespace.", nameof(template));
             if (Templates.Contains(template)) throw new ArgumentException("Template already exists.", nameof(template));
 
             Templates.Add(template);
@@ -47,7 +47,7 @@ public class BestPracticeEnforcer : IBestPracticeEnforcer
         try
         {
             ArgumentNullException.ThrowIfNull(template);
-            if (string.IsNullOrWhiteSpace(template.Text)) throw new ArgumentException("Template text cannot be null or whitespace.", nameof(template));
+            if (string.IsNullOrWhiteSpace(TextTemplate.GetFlowDocumentPlainText(template.Text))) throw new ArgumentException("Template text cannot be null or whitespace.", nameof(template));
             if (!Templates.Contains(template)) throw new ArgumentException("Template does not exist.", nameof(template));
 
             Templates.Remove(template);

--- a/AMFormsCST.Desktop/AMFormsCST.Desktop.csproj
+++ b/AMFormsCST.Desktop/AMFormsCST.Desktop.csproj
@@ -36,6 +36,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="Helpers\RichTextBoxHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="Assets\AMLogo.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/AMFormsCST.Desktop/Controls/RichTextToolbar.xaml
+++ b/AMFormsCST.Desktop/Controls/RichTextToolbar.xaml
@@ -1,0 +1,82 @@
+<UserControl x:Class="AMFormsCST.Desktop.Controls.RichTextToolbar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             mc:Ignorable="d" 
+             d:DesignHeight="50" d:DesignWidth="385">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <Style x:Key="LowProfileToggle" TargetType="ToggleButton">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border Background="{TemplateBinding Background}" 
+                         BorderBrush="{TemplateBinding BorderBrush}" 
+                         BorderThickness="{TemplateBinding BorderThickness}"
+                         CornerRadius="3">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+    <StackPanel Orientation="Horizontal">
+        <ToggleButton x:Name="ToggleVisibilityButton" IsChecked="True" ToolTip="Show/Hide Toolbar" Style="{StaticResource LowProfileToggle}">
+            <ui:SymbolIcon FontSize="12">
+                <ui:SymbolIcon.Style>
+                    <Style TargetType="ui:SymbolIcon">
+                        <Setter Property="Symbol" Value="ChevronLeft20" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsChecked, ElementName=ToggleVisibilityButton}" Value="False">
+                                <Setter Property="Symbol" Value="ChevronRight20" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ui:SymbolIcon.Style>
+            </ui:SymbolIcon>
+        </ToggleButton>
+
+        <StackPanel Orientation="Horizontal" 
+                    Visibility="{Binding ElementName=ToggleVisibilityButton, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <ToggleButton x:Name="BtnBold" Click="BtnBold_Click" ToolTip="Bold">
+                <ui:SymbolIcon Symbol="TextBold20" />
+            </ToggleButton>
+            <ToggleButton x:Name="BtnItalic" Click="BtnItalic_Click" Margin="5,0,0,0" ToolTip="Italic">
+                <ui:SymbolIcon Symbol="TextItalic20" />
+            </ToggleButton>
+            <ToggleButton x:Name="BtnUnderline" Click="BtnUnderline_Click" Margin="5,0,0,0" ToolTip="Underline">
+                <ui:SymbolIcon Symbol="TextUnderline20" />
+            </ToggleButton>
+
+            <Separator Margin="5,0,5,0"/>
+
+            <ToggleButton x:Name="BtnBullets" Click="BtnBullets_Click" Margin="5,0,0,0" ToolTip="Bulleted List">
+                <ui:SymbolIcon Symbol="TextBulletList20" />
+            </ToggleButton>
+            <ToggleButton x:Name="BtnNumbering" Click="BtnNumbering_Click" Margin="5,0,0,0" ToolTip="Numbered List">
+                <ui:SymbolIcon Symbol="TextNumberListLtr20" />
+            </ToggleButton>
+
+            <Separator Margin="5,0,5,0"/>
+
+            <Button x:Name="BtnIncreaseFont" Click="BtnIncreaseFont_Click" Margin="5,0,0,0" ToolTip="Increase Font Size">
+                <ui:SymbolIcon Symbol="FontIncrease24" />
+            </Button>
+            <Button x:Name="BtnDecreaseFont" Click="BtnDecreaseFont_Click" Margin="5,0,0,0" ToolTip="Decrease Font Size">
+                <ui:SymbolIcon Symbol="FontDecrease24" />
+            </Button>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/AMFormsCST.Desktop/Controls/RichTextToolbar.xaml.cs
+++ b/AMFormsCST.Desktop/Controls/RichTextToolbar.xaml.cs
@@ -1,0 +1,151 @@
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+
+namespace AMFormsCST.Desktop.Controls
+{
+    public partial class RichTextToolbar : UserControl
+    {
+        public static readonly DependencyProperty TargetProperty =
+            DependencyProperty.Register(
+                "Target",
+                typeof(RichTextBox),
+                typeof(RichTextToolbar),
+                new PropertyMetadata(null, OnTargetChanged));
+
+        public RichTextBox Target
+        {
+            get => (RichTextBox)GetValue(TargetProperty);
+            set => SetValue(TargetProperty, value);
+        }
+
+        public RichTextToolbar()
+        {
+            InitializeComponent();
+        }
+
+        private static void OnTargetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is RichTextToolbar toolbar)
+            {
+                if (e.OldValue is RichTextBox oldRtb)
+                {
+                    oldRtb.SelectionChanged -= toolbar.OnRichTextBoxSelectionChanged;
+                }
+                if (e.NewValue is RichTextBox newRtb)
+                {
+                    newRtb.SelectionChanged += toolbar.OnRichTextBoxSelectionChanged;
+                }
+            }
+        }
+
+        private void OnRichTextBoxSelectionChanged(object sender, RoutedEventArgs e)
+        {
+            UpdateToolbar();
+        }
+
+        private void UpdateToolbar()
+        {
+            if (Target == null) return;
+
+            BtnBold.IsChecked = IsSelectionPropertyActive(TextElement.FontWeightProperty, FontWeights.Bold);
+            BtnItalic.IsChecked = IsSelectionPropertyActive(TextElement.FontStyleProperty, FontStyles.Italic);
+            BtnUnderline.IsChecked = IsSelectionPropertyActive(TextDecorations.Underline);
+
+            var currentList = GetSelectionList();
+            BtnBullets.IsChecked = currentList?.MarkerStyle == TextMarkerStyle.Disc;
+            BtnNumbering.IsChecked = currentList?.MarkerStyle == TextMarkerStyle.Decimal;
+        }
+
+        private List? GetSelectionList()
+        {
+            if (Target == null || Target.Selection.IsEmpty) return null;
+
+            var startPara = Target.Selection.Start.Paragraph;
+            var endPara = Target.Selection.End.Paragraph;
+
+            if (startPara == null || endPara == null || startPara != endPara) return null;
+
+            if (startPara.Parent is ListItem listItem)
+            {
+                return listItem.Parent as List;
+            }
+
+            return null;
+        }
+
+        private bool IsSelectionPropertyActive(DependencyProperty property, object expectedValue)
+        {
+            var value = Target.Selection.GetPropertyValue(property);
+            return value != DependencyProperty.UnsetValue && value != null && value.Equals(expectedValue);
+        }
+
+        private bool IsSelectionPropertyActive(TextDecorationCollection expectedValue)
+        {
+            var value = Target.Selection.GetPropertyValue(Inline.TextDecorationsProperty);
+            return value != DependencyProperty.UnsetValue && value is TextDecorationCollection tdc && tdc.Any() && tdc.Equals(expectedValue);
+        }
+
+        private void BtnBold_Click(object sender, RoutedEventArgs e)
+        {
+            if (Target == null) return;
+            EditingCommands.ToggleBold.Execute(null, Target);
+            Target.Focus();
+        }
+
+        private void BtnItalic_Click(object sender, RoutedEventArgs e)
+        {
+            if (Target == null) return;
+            EditingCommands.ToggleItalic.Execute(null, Target);
+            Target.Focus();
+        }
+
+        private void BtnUnderline_Click(object sender, RoutedEventArgs e)
+        {
+            if (Target == null) return;
+            EditingCommands.ToggleUnderline.Execute(null, Target);
+            Target.Focus();
+        }
+
+        private void BtnBullets_Click(object sender, RoutedEventArgs e)
+        {
+            if (Target == null) return;
+            EditingCommands.ToggleBullets.Execute(null, Target);
+            Target.Focus();
+        }
+
+        private void BtnNumbering_Click(object sender, RoutedEventArgs e)
+        {
+            if (Target == null) return;
+            EditingCommands.ToggleNumbering.Execute(null, Target);
+            Target.Focus();
+        }
+
+        private void BtnDecreaseFont_Click(object sender, RoutedEventArgs e)
+        {
+            ChangeFontSize(-2);
+        }
+
+        private void BtnIncreaseFont_Click(object sender, RoutedEventArgs e)
+        {
+            ChangeFontSize(2);
+        }
+
+        private void ChangeFontSize(double delta)
+        {
+            if (Target == null) return;
+
+            var currentSizeValue = Target.Selection.GetPropertyValue(TextElement.FontSizeProperty);
+            if (currentSizeValue == DependencyProperty.UnsetValue || currentSizeValue == null) return;
+
+            var currentSize = (double)currentSizeValue;
+            var newSize = currentSize + delta;
+
+            if (newSize < 1) newSize = 1;
+
+            Target.Selection.ApplyPropertyValue(TextElement.FontSizeProperty, newSize);
+            Target.Focus();
+        }
+    }
+}

--- a/AMFormsCST.Desktop/Converters/FlowDocumentToTextConverter.cs
+++ b/AMFormsCST.Desktop/Converters/FlowDocumentToTextConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Documents;
+
+namespace AMFormsCST.Desktop.Converters
+{
+    public class FlowDocumentToTextConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is FlowDocument doc)
+            {
+                return new TextRange(doc.ContentStart, doc.ContentEnd).Text;
+            }
+            return string.Empty;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var flowDocument = new FlowDocument();
+            if (value is string text)
+            {
+                flowDocument.Blocks.Add(new Paragraph(new Run(text)));
+            }
+            return flowDocument;
+        }
+    }
+}

--- a/AMFormsCST.Desktop/Helpers/RichTextBoxHelper.cs
+++ b/AMFormsCST.Desktop/Helpers/RichTextBoxHelper.cs
@@ -1,0 +1,37 @@
+using System.Windows;
+using System.Windows.Documents;
+using Wpf.Ui.Controls;
+
+namespace AMFormsCST.Desktop.Helpers
+{
+    public static class RichTextBoxHelper
+    {
+        public static readonly DependencyProperty DocumentProperty =
+            DependencyProperty.RegisterAttached(
+                "Document",
+                typeof(FlowDocument),
+                typeof(RichTextBoxHelper),
+                new FrameworkPropertyMetadata(
+                    null,
+                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                    OnDocumentChanged));
+
+        public static FlowDocument GetDocument(DependencyObject dp)
+        {
+            return (FlowDocument)dp.GetValue(DocumentProperty);
+        }
+
+        public static void SetDocument(DependencyObject dp, FlowDocument value)
+        {
+            dp.SetValue(DocumentProperty, value);
+        }
+
+        private static void OnDocumentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is RichTextBox rtb)
+            {
+                rtb.Document = e.NewValue as FlowDocument ?? new FlowDocument();
+            }
+        }
+    }
+}

--- a/AMFormsCST.Desktop/Models/Templates/DepricatedTemplate.cs
+++ b/AMFormsCST.Desktop/Models/Templates/DepricatedTemplate.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 using AMFormsCST.Core.Interfaces;
+using System.Windows.Documents;
 
 namespace AMFormsCST.Desktop.Models.Templates;
 public class DeprecatedTemplate
@@ -66,7 +67,7 @@ public class DeprecatedTemplate
         var template = new TextTemplate(
             name: deprecated.Name,
             description: "[Converted]",
-            text: formattedText,
+            text: new() { Blocks = { new Paragraph(new Run(formattedText)) } },
             type: ConvertType(deprecated.Type)
         );
 

--- a/AMFormsCST.Desktop/Services/DesignTimeDialogService.cs
+++ b/AMFormsCST.Desktop/Services/DesignTimeDialogService.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using MessageBoxResult = System.Windows.MessageBoxResult;
 
 namespace AMFormsCST.Desktop.Services;
@@ -10,9 +11,8 @@ public class DesignTimeDialogService : IDialogService
     => MessageBoxResult.OK;
     
 
-    public (bool? DialogResult, string TemplateName, string TemplateDescription, string TemplateContent) ShowNewTemplateDialog(string? name = null, string? description = null, string? content = null)
-    => (true, "DesignTimeTemplate", "A template for design time", "Content");
-    
+    public (bool? DialogResult, string TemplateName, string TemplateDescription, FlowDocument TemplateContent) ShowNewTemplateDialog(string? name = null, string? description = null, FlowDocument? content = null)
+    => (true, "DesignTimeTemplate", "A template for design time", new() { Blocks = { new Paragraph(new Run("Content")) } });
 
     public bool ShowPageHostDialog(Page contentPage, string title = "Page Preview", bool canConfirm = false)
     => true;

--- a/AMFormsCST.Desktop/Services/DesignTimeSupportTool.cs
+++ b/AMFormsCST.Desktop/Services/DesignTimeSupportTool.cs
@@ -6,6 +6,7 @@ using AMFormsCST.Core.Types.BestPractices.Models;
 using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 using Moq;
 using System.Globalization;
+using System.Windows.Documents;
 using static AMFormsCST.Core.Types.BestPractices.TextTemplates.Models.TextTemplate;
 
 namespace AMFormsCST.Desktop.Services;
@@ -56,9 +57,9 @@ public class DesignTimeSupportTool : ISupportTool
 
         var templates = new List<TextTemplate>
         {
-            new("Case Intro", "Standard introduction for a new case.", "Hello {FirstName}, this is in regards to case #{CaseNumber}.", TemplateType.InternalComments),
-            new("Form Issue", "Template for reporting a form issue.", "The form {FormName} is having an issue. Details: {IssueDetails}", TemplateType.Other),
-            new("Closing", "Standard case closing.", "Thank you for your time. Case #{CaseNumber} will now be closed.", TemplateType.Email)
+            new("Case Intro", "Standard introduction for a new case.", new() { Blocks = { new Paragraph(new Run("Hello {FirstName}, this is in regards to case #{CaseNumber}.")) } }, TemplateType.InternalComments),
+            new("Form Issue", "Template for reporting a form issue.", new() { Blocks = { new Paragraph(new Run("The form {FormName} is having an issue. Details: {IssueDetails}")) } }, TemplateType.Other),
+            new("Closing", "Standard case closing.", new() { Blocks = { new Paragraph(new Run("Thank you for your time. Case #{CaseNumber} will now be closed.")) } }, TemplateType.Email)
         };
         mockEnforcer.Setup(e => e.Templates).Returns(templates);
 

--- a/AMFormsCST.Desktop/Services/DialogService.cs
+++ b/AMFormsCST.Desktop/Services/DialogService.cs
@@ -4,6 +4,8 @@ using System.Windows;
 using System.Windows.Controls;
 using AMFormsCST.Core.Interfaces;
 using AMFormsCST.Desktop.ViewModels.Dialogs;
+using System.Windows.Documents;
+using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 
 namespace AMFormsCST.Desktop.Services;
 
@@ -33,13 +35,13 @@ public class DialogService : IDialogService
     }
 
     /// <inheritdoc />
-    public (bool? DialogResult, string TemplateName, string TemplateDescription, string TemplateContent) ShowNewTemplateDialog(string? name = null, string? description = null, string? content = null)
+    public (bool? DialogResult, string TemplateName, string TemplateDescription, FlowDocument TemplateContent) ShowNewTemplateDialog(string? name = null, string? description = null, FlowDocument? content = null)
     {
         _logger?.LogInfo("ShowNewTemplateDialog called.");
         var dialog = new NewTemplateDialog(name, description, content);
         var result = dialog.ShowDialog();
         _logger?.LogInfo($"NewTemplateDialog result: {result}");
-        return (result, dialog.TemplateName, dialog.TemplateDescription, dialog.TemplateContent);
+        return (result, dialog.TemplateName, dialog.TemplateDescription, ((NewTemplateDialogViewModel)dialog.DataContext).TemplateContent);
     }
 
     /// <inheritdoc />

--- a/AMFormsCST.Desktop/Services/Interfaces/IDialogService.cs
+++ b/AMFormsCST.Desktop/Services/Interfaces/IDialogService.cs
@@ -1,26 +1,26 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 
-namespace AMFormsCST.Desktop.Services
+namespace AMFormsCST.Desktop.Services;
+
+public interface IDialogService
 {
-    public interface IDialogService
+    public enum DialogResult
     {
-        public enum DialogResult
-        {
-            Primary,
-            Secondary,
-            Cancel
-        }
-
-        MessageBoxResult ShowMessageBox(string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon);
-
-        (bool? DialogResult, string TemplateName, string TemplateDescription, string TemplateContent) ShowNewTemplateDialog(string? name = null, string? description = null, string? content = null);
-
-        bool ShowPageHostDialog(Page contentPage, string title = "Page Prview", bool canConfirm = false);
-
-        string? ShowOpenFileDialog(string filter);
-        string? ShowOpenFileDialog(string filter, string defaultDirectory);
-        DialogResult ShowDialog(string title, Page content);
-        public (bool Result, string Title, string Description) ShowBugReportDialog();
+        Primary,
+        Secondary,
+        Cancel
     }
+
+    MessageBoxResult ShowMessageBox(string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon);
+
+    (bool? DialogResult, string TemplateName, string TemplateDescription, FlowDocument TemplateContent) ShowNewTemplateDialog(string? name = null, string? description = null, FlowDocument? content = null);
+
+    bool ShowPageHostDialog(Page contentPage, string title = "Page Prview", bool canConfirm = false);
+
+    string? ShowOpenFileDialog(string filter);
+    string? ShowOpenFileDialog(string filter, string defaultDirectory);
+    DialogResult ShowDialog(string title, Page content);
+    public (bool Result, string Title, string Description) ShowBugReportDialog();
 }

--- a/AMFormsCST.Desktop/ViewModels/Dialogs/NewTemplateDialogViewModel.cs
+++ b/AMFormsCST.Desktop/ViewModels/Dialogs/NewTemplateDialogViewModel.cs
@@ -2,6 +2,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Windows;
+using System.Windows.Documents;
+using static AMFormsCST.Core.Types.BestPractices.TextTemplates.Models.TextTemplate;
 
 namespace AMFormsCST.Desktop.ViewModels.Dialogs;
 
@@ -14,10 +16,10 @@ public partial class NewTemplateDialogViewModel : ObservableObject
     private string _templateDescription = string.Empty;
 
     [ObservableProperty]
-    private string _templateContent = string.Empty;
+    private FlowDocument _templateContent = new();
 
     [ObservableProperty]
-    private TextTemplate.TemplateType _templateType = TextTemplate.TemplateType.Other;
+    private TemplateType _templateType;
 
     public NewTemplateDialogViewModel()
     {

--- a/AMFormsCST.Desktop/ViewModels/Pages/DashboardViewModel.cs
+++ b/AMFormsCST.Desktop/ViewModels/Pages/DashboardViewModel.cs
@@ -16,6 +16,7 @@ using System.ComponentModel;
 using System.Runtime.ExceptionServices;
 using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Documents;
 using Wpf.Ui;
 
 namespace AMFormsCST.Desktop.ViewModels.Pages;
@@ -51,12 +52,12 @@ public partial class DashboardViewModel : ViewModel
         var note1 = new NoteModel("x")
         {
             CaseNumber = "00123456",
-            Notes = "This is the first sample note."
+            Notes = new() { Blocks = { new Paragraph(new Run("This is the first sample note.")) } }
         };
         var note2 = new NoteModel("x")
         {
             CaseNumber = "00234567",
-            Notes = "This is the second sample note."
+            Notes = new() { Blocks = { new Paragraph(new Run("This is the second sample note.")) } }
         };
 
         var contact1 = new Models.Contact("x") { Name = "John Doe", Email = "john.doe@email.com", Phone = "888-555-1234", PhoneExtension = "1234" };
@@ -70,7 +71,7 @@ public partial class DashboardViewModel : ViewModel
         note1.Dealers.Add(dealer1);
         note1.Dealers.FirstOrDefault(x => !x.IsBlank, note1.Dealers.First())?.Select();
 
-        var form1 = new Models.Form(note1) { Name = "Sample Form 1", Notes = "Notes for form 1" };
+        var form1 = new Models.Form(note1) { Name = "Sample Form 1", Notes = new() { Blocks = { new Paragraph(new Run("Notes for form 1")) } } };
         var testDeal1 = new Models.TestDeal { DealNumber = "D001", Purpose = "Test purpose 1" };
         form1.TestDeals.Add(testDeal1);
         form1.TestDeals.FirstOrDefault(x => !x.IsBlank, form1.TestDeals.First())?.Select();
@@ -868,7 +869,8 @@ public partial class DashboardViewModel : ViewModel
                 ? string.Join(Environment.NewLine, lines.Skip(descriptionIdx + 1).Take(separatorIdx - descriptionIdx - 1)).Trim()
                 : string.Empty;
 
-            note.Notes = $"{subject}{Environment.NewLine}{description}".Trim();
+            note.Notes = new FlowDocument();
+            note.Notes.Blocks.Add(new Paragraph(new Run($"{subject}{Environment.NewLine}{description}".Trim())));
 
             var contact = note.Contacts[0];
             contact.Name = GetValueAfter("Contact Name");

--- a/AMFormsCST.Desktop/ViewModels/Pages/Tools/TemplatesViewModel.cs
+++ b/AMFormsCST.Desktop/ViewModels/Pages/Tools/TemplatesViewModel.cs
@@ -3,6 +3,7 @@ using AMFormsCST.Core.Interfaces.Utils;
 using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 using AMFormsCST.Desktop.Models.Templates;
 using AMFormsCST.Desktop.Services;
+using AMFormsCST.Desktop.ViewModels.Dialogs;
 using AMFormsCST.Desktop.ViewModels.Pages.Tools.Templates;
 using AMFormsCST.Desktop.Views.Dialogs;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,6 +14,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Data;
+using System.Windows.Documents;
 
 namespace AMFormsCST.Desktop.ViewModels.Pages.Tools;
 
@@ -181,7 +183,7 @@ public partial class TemplatesViewModel : ViewModel
                 new TextTemplate(
                     dialog.TemplateName,
                     dialog.TemplateDescription,
-                    dialog.TemplateContent,
+                    ((NewTemplateDialogViewModel)dialog.DataContext).TemplateContent,
                     dialog.Type),
                 _supportTool);
 
@@ -223,7 +225,7 @@ public partial class TemplatesViewModel : ViewModel
 
             SelectedTemplate.Template.Name = dialog.TemplateName;
             SelectedTemplate.Template.Description = dialog.TemplateDescription;
-            SelectedTemplate.Template.Text = dialog.TemplateContent;
+            SelectedTemplate.Template.Text = ((NewTemplateDialogViewModel)dialog.DataContext).TemplateContent;
             SelectedTemplate.Template.Type = dialog.Type;
 
             SelectedTemplate.RefreshTemplateData();
@@ -277,7 +279,7 @@ public partial class TemplatesViewModel : ViewModel
         {
             if (item == SelectedTemplate) return;
 
-            Clipboard.SetText(SelectedTemplate?.Output);
+            Clipboard.SetText(TextTemplate.GetFlowDocumentPlainText(SelectedTemplate?.Output));
             _logger?.LogInfo($"Template output copied: {SelectedTemplate?.Template.Name}");
         }
         catch (Exception ex)

--- a/AMFormsCST.Desktop/Views/Dialogs/NewTemplateDialog.xaml
+++ b/AMFormsCST.Desktop/Views/Dialogs/NewTemplateDialog.xaml
@@ -8,6 +8,8 @@
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
         xmlns:models="clr-namespace:AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;assembly=AMFormsCST.Core" 
                  xmlns:sys="clr-namespace:System;assembly=System.Runtime"
+                 xmlns:controls="clr-namespace:AMFormsCST.Desktop.Controls"
+                 xmlns:helpers="clr-namespace:AMFormsCST.Desktop.Helpers"
                  mc:Ignorable="d"
         Title="Create New Template" Height="450" Width="600"
         WindowStartupLocation="CenterScreen"
@@ -20,7 +22,6 @@
 
         <Grid Margin="15,40,15,15">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -45,10 +46,12 @@
                       SelectedItem="{Binding TemplateType, Mode=TwoWay}" />
 
             <Label Grid.Row="3" Grid.Column="0" Content="Content:"/>
-            <ui:TextBox Grid.Row="3" Grid.Column="1" Margin="5" Text="{Binding TemplateContent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        TextWrapping="Wrap" AcceptsReturn="True" MinHeight="150" VerticalScrollBarVisibility="Auto"/>
+            <controls:RichTextToolbar Grid.Row="3" Grid.Column="1" Target="{Binding ElementName=ContentRichTextBox}" Margin="5,0,0,2"/>
+            <ui:RichTextBox x:Name="ContentRichTextBox" Grid.Row="4" Grid.Column="1" Margin="5" 
+                          helpers:RichTextBoxHelper.Document="{Binding TemplateContent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                          AcceptsReturn="True" MinHeight="150" VerticalScrollBarVisibility="Auto"/>
 
-            <StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+            <StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
                 <ui:Button Content="Create" Command="{Binding CreateCommand}" Margin="0,0,10,0" MinWidth="80" IsDefault="True"
                            CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ui:FluentWindow}}}" x:Name="ConfirmButton"/>
                 <ui:Button Content="Cancel" MinWidth="80" IsCancel="True"/>

--- a/AMFormsCST.Desktop/Views/Dialogs/NewTemplateDialog.xaml.cs
+++ b/AMFormsCST.Desktop/Views/Dialogs/NewTemplateDialog.xaml.cs
@@ -22,7 +22,7 @@ namespace AMFormsCST.Desktop.Views.Dialogs;
 /// </summary>
 public partial class NewTemplateDialog : FluentWindow
 {
-    public NewTemplateDialog(string? Name = null, string? Description = null, string? Content = null, TextTemplate.TemplateType type = TextTemplate.TemplateType.Other)
+    public NewTemplateDialog(string? Name = null, string? Description = null, FlowDocument? Content = null, TextTemplate.TemplateType type = TextTemplate.TemplateType.Other)
     {
         InitializeComponent();
         
@@ -30,7 +30,7 @@ public partial class NewTemplateDialog : FluentWindow
         {
             TemplateName = Name ?? string.Empty,
             TemplateDescription = Description ?? string.Empty,
-            TemplateContent = Content ?? string.Empty,
+            TemplateContent = Content ?? new(),
             TemplateType = type
         }; // Set the DataContext
 
@@ -42,7 +42,7 @@ public partial class NewTemplateDialog : FluentWindow
     // Optional: Properties to easily access the values from the ViewModel
     public string TemplateName => ((NewTemplateDialogViewModel)DataContext).TemplateName;
     public string TemplateDescription => ((NewTemplateDialogViewModel)DataContext).TemplateDescription;
-    public string TemplateContent => ((NewTemplateDialogViewModel)DataContext).TemplateContent;
+    public string TemplateContent => TextTemplate.GetFlowDocumentPlainText(((NewTemplateDialogViewModel)DataContext).TemplateContent);
     public TextTemplate.TemplateType Type => ((NewTemplateDialogViewModel)DataContext).TemplateType;
 
     private void CustomTitleBarArea_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/AMFormsCST.Desktop/Views/Pages/DashboardPage.xaml
+++ b/AMFormsCST.Desktop/Views/Pages/DashboardPage.xaml
@@ -7,10 +7,15 @@
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml" 
       xmlns:viewModels="clr-namespace:AMFormsCST.Desktop.ViewModels.Pages"
       xmlns:controls="clr-namespace:AMFormsCST.Desktop.Controls"
+      xmlns:converters="clr-namespace:AMFormsCST.Desktop.Converters"
+      xmlns:helpers="clr-namespace:AMFormsCST.Desktop.Helpers"
       mc:Ignorable="d"
       d:DesignHeight="900" d:DesignWidth="1200"
       Title="DashboardPage"
-      d:DataContext="{d:DesignInstance viewModels:DashboardViewModel,  IsDesignTimeCreatable=True}" ScrollViewer.VerticalScrollBarVisibility="Disabled" ScrollViewer.CanContentScroll="False">
+      d:DataContext="{d:DesignInstance viewModels:DashboardViewModel,  IsDesignTimeCreatable=true}" ScrollViewer.VerticalScrollBarVisibility="Disabled" ScrollViewer.CanContentScroll="False">
+    <Page.Resources>
+        <converters:FlowDocumentToTextConverter x:Key="FlowDocumentToTextConverter" />
+    </Page.Resources>
 
     <Grid ScrollViewer.VerticalScrollBarVisibility="Disabled" x:Name="OutermostGrid">
         <Grid.ColumnDefinitions>
@@ -69,6 +74,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
@@ -82,10 +88,11 @@
             
 
             <Label Content="Notes:"  Margin=" 0, 0, 0, 0" Grid.Row="1" VerticalAlignment="Bottom"/>
-            <ui:TextBox Text="{Binding SelectedNote.Notes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                            AcceptsReturn="True" ClearButtonEnabled="True" VerticalAlignment="Stretch" Grid.Row="2"
-                            Margin="0,0,0,10" ToolTip="General notes for this case." TextWrapping="Wrap"/>
-            <controls:CopyButton TextToCopy="{Binding SelectedNote.Notes}" 
+            <controls:RichTextToolbar Grid.Row="2" Target="{Binding ElementName=NoteRichTextBox}" Margin="0,0,0,2" HorizontalAlignment="Left"/>
+            <ui:RichTextBox x:Name="NoteRichTextBox" helpers:RichTextBoxHelper.Document="{Binding SelectedNote.Notes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                            AcceptsReturn="True" VerticalAlignment="Stretch" Grid.Row="3"
+                            Margin="0,0,0,10" ToolTip="General notes for this case." VerticalScrollBarVisibility="Auto" />
+            <controls:CopyButton TextToCopy="{Binding SelectedNote.Notes, Converter={StaticResource FlowDocumentToTextConverter}}" 
                                  Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="5" Grid.RowSpan="2" ToolTip="Copy notes to clipboard."/>
         </Grid>
 
@@ -164,12 +171,13 @@
             </Grid.ColumnDefinitions>
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="*" />
+                <RowDefinition Height="auto" />
             </Grid.RowDefinitions>
 
             <controls:ManagedObservableCollectionSelector ItemsSource="{Binding SelectedNote.Forms}" 
@@ -209,14 +217,15 @@
                                  HorizontalAlignment="Left" Margin="5,0,0,0" ToolTip="Copy deal number to clipboard."/>
 
             <Label Content="Notes: " VerticalAlignment="Top" HorizontalAlignment="Center"  Grid.Row="4" Grid.Column="0"/>
-            <ui:TextBox Text="{Binding SelectedNote.SelectedForm.Notes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                            ClearButtonEnabled="True" VerticalAlignment="Center" MinWidth="256" 
-                        Margin="0,0,0,0" AcceptsReturn="True" MinHeight="100" Grid.Row="4" 
-                        Grid.Column="1" HorizontalAlignment="Stretch" ToolTip="Notes specific to this form." TextWrapping="Wrap"/>
-            <controls:CopyButton TextToCopy="{Binding SelectedNote.SelectedForm.Notes}" Grid.Row="4" Grid.Column="2" 
+            <controls:RichTextToolbar Grid.Row="4" Grid.Column="1" Target="{Binding ElementName=FormNotesRichTextBox}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,0,0,2"/>
+            <ui:RichTextBox x:Name="FormNotesRichTextBox" helpers:RichTextBoxHelper.Document="{Binding SelectedNote.SelectedForm.Notes, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                             VerticalAlignment="Stretch" MinWidth="256" 
+                        Margin="0,0,0,0" AcceptsReturn="True" MinHeight="100" Grid.Row="5" 
+                        Grid.Column="1" HorizontalAlignment="Stretch" ToolTip="Notes specific to this form." VerticalScrollBarVisibility="Auto" />
+            <controls:CopyButton TextToCopy="{Binding SelectedNote.SelectedForm.Notes, Converter={StaticResource FlowDocumentToTextConverter}}" Grid.Row="5" Grid.Column="2" 
                                  HorizontalAlignment="Left" Margin="5,0,0,0" VerticalAlignment="Top" ToolTip="Copy form notes to clipboard."/>
 
-            <StackPanel Orientation="Horizontal" Margin="0,5,0,0" Grid.Row="5" Grid.Column="1">
+            <StackPanel Orientation="Horizontal" Margin="0,5,0,0" Grid.Row="6" Grid.Column="1">
                 <Label Content="Pdf" VerticalAlignment="Center"/>
                 <ui:ToggleSwitch Margin="5,0,5,0" ToolTip="Toggle PDF/Impact form type."/>
                 <Label Content="Impact" Margin="0,0,5,0" VerticalAlignment="Center"/>

--- a/AMFormsCST.Desktop/Views/Pages/Tools/TemplatesPage.xaml
+++ b/AMFormsCST.Desktop/Views/Pages/Tools/TemplatesPage.xaml
@@ -7,7 +7,8 @@
       xmlns:coreInterfaces="clr-namespace:AMFormsCST.Core.Interfaces.BestPractices;assembly=AMFormsCST.Core"
       xmlns:viewModels="clr-namespace:AMFormsCST.Desktop.ViewModels.Pages.Tools"
       xmlns:templateViewModels="clr-namespace:AMFormsCST.Desktop.ViewModels.Pages.Tools.Templates"
-      xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml" 
+      xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+      xmlns:helpers="clr-namespace:AMFormsCST.Desktop.Helpers"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
       Title="TemplatesPage"
@@ -55,60 +56,46 @@
                 </ListBox>
             </ui:DynamicScrollViewer>
         </DockPanel>
-        <ui:DynamicScrollViewer Grid.Column="1">
-        <StackPanel Orientation="Vertical">
-            <Label Content="{Binding SelectedTemplate.Template.Name}" HorizontalAlignment="Center"/>
-            <Label Content="{Binding SelectedTemplate.Template.Description}" HorizontalAlignment="Center"/>
-            <Label Content="{Binding SelectedTemplate.Template.Type}" HorizontalAlignment="Center"/>
-                <Border Background="#1AFFFFFF" BorderBrush="LightGray" BorderThickness="1" Margin="0,5,10,0" CornerRadius="5" HorizontalAlignment="Center" >
+        <Grid Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
 
+                <Label Grid.Row="0" Content="{Binding SelectedTemplate.Template.Name}" HorizontalAlignment="Center"/>
+                <Label Grid.Row="1" Content="{Binding SelectedTemplate.Template.Description}" HorizontalAlignment="Center"/>
+                <Label Grid.Row="2" Content="{Binding SelectedTemplate.Template.Type}" HorizontalAlignment="Center"/>
+
+                <Border Grid.Row="3" Background="#1AFFFFFF" BorderBrush="LightGray" BorderThickness="1" Margin="0,5,10,0" CornerRadius="5" HorizontalAlignment="Center" >
                     <StackPanel Orientation="Horizontal">
-                        <ui:Button
-              Command="{Binding RefreshTemplateCommand}"
-              Margin="5"
-              Padding="10,5"
-              HorizontalAlignment="Left">
+                        <ui:Button Command="{Binding RefreshTemplateCommand}" Margin="5" Padding="10,5" HorizontalAlignment="Left">
                             <ui:SymbolIcon Symbol="ArrowSync12"/>
                         </ui:Button>
-                        <ui:Button
-              Command="{Binding CopyTemplateCommand}"
-              Margin="5"
-              Padding="10,5"
-              HorizontalAlignment="Left">
+                        <ui:Button Command="{Binding CopyTemplateCommand}" Margin="5" Padding="10,5" HorizontalAlignment="Left">
                             <ui:SymbolIcon Symbol="Copy24"/>
                         </ui:Button>
-                        <ui:Button
-              Command="{Binding AddTemplateCommand}"
-              Margin="5"
-              Padding="10,5"
-              HorizontalAlignment="Left">
+                        <ui:Button Command="{Binding AddTemplateCommand}" Margin="5" Padding="10,5" HorizontalAlignment="Left">
                             <ui:SymbolIcon Symbol="Add24"/>
                         </ui:Button>
-                        <ui:Button
-              Command="{Binding EditTemplateCommand}"
-              Margin="5"
-              Padding="10,5"
-              HorizontalAlignment="Left">
+                        <ui:Button Command="{Binding EditTemplateCommand}" Margin="5" Padding="10,5" HorizontalAlignment="Left">
                             <ui:SymbolIcon Symbol="Edit24"/>
                         </ui:Button>
-                        <ui:Button
-              Command="{Binding RemoveTemplateCommand}"
-              Margin="5"
-              Padding="10,5"
-              HorizontalAlignment="Left">
+                        <ui:Button Command="{Binding RemoveTemplateCommand}" Margin="5" Padding="10,5" HorizontalAlignment="Left">
                             <ui:SymbolIcon Symbol="Delete24"/>
                         </ui:Button>
-                        <ui:Button
-              Command="{Binding ImportTemplateCommand}"
-              Margin="5"
-              Padding="10,5"
-              HorizontalAlignment="Left">
+                        <ui:Button Command="{Binding ImportTemplateCommand}" Margin="5" Padding="10,5" HorizontalAlignment="Left">
                             <ui:SymbolIcon Symbol="ArrowDownload24"/>
                         </ui:Button>
                     </StackPanel>
                 </Border>
-                <ui:TextBox Text="{Binding SelectedTemplate.Output, Mode=OneWay}" TextWrapping="Wrap" Margin="10" IsReadOnly="True" IsReadOnlyCaretVisible="True"/>
-                <ItemsControl ItemsSource="{Binding SelectedTemplate.Variables}" HorizontalAlignment="Left">
+
+                <ui:RichTextBox Grid.Row="4" helpers:RichTextBoxHelper.Document="{Binding SelectedTemplate.Output, Mode=OneWay}" Margin="10" IsReadOnly="True" VerticalScrollBarVisibility="Auto"/>
+
+                <ItemsControl Grid.Row="5" ItemsSource="{Binding SelectedTemplate.Variables}" HorizontalAlignment="Left">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type templateViewModels:TemplateVariableViewModel}">
                             <ui:TextBox Margin="10,0,0,5" 
@@ -123,7 +110,6 @@
                         </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                 </ItemsControl>
-            </StackPanel>
-        </ui:DynamicScrollViewer>
+            </Grid>
     </Grid>
 </Page>

--- a/AMFormsCST.Test/Core/Types/BestPractices/TextTemplates/Models/TextTemplateTests.cs
+++ b/AMFormsCST.Test/Core/Types/BestPractices/TextTemplates/Models/TextTemplateTests.cs
@@ -5,6 +5,7 @@ using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Windows.Documents;
 using Assert = Xunit.Assert;
 
 namespace AMFormsCST.Test.Core.Types.BestPractices.TextTemplates.Models;
@@ -49,7 +50,8 @@ public class TextTemplateTests
     public void GetVariables_FindsVariablesInText_AndReturnsThem()
     {
         // Arrange
-        var template = new TextTemplate("Test", "Desc", "Case number is {CaseNumber} and user is $User.", TextTemplate.TemplateType.Other);
+        var flowDoc = new FlowDocument(new Paragraph(new Run("Case number is {CaseNumber} and user is $User.")));
+        var template = new TextTemplate("Test", "Desc", flowDoc, TextTemplate.TemplateType.Other);
     
         // Act
         var foundVariables = template.GetVariables(_mockSupportTool.Object);
@@ -64,7 +66,8 @@ public class TextTemplateTests
     public void GetVariables_WhenNoVariablesInText_ReturnsEmptyList()
     {
         // Arrange
-        var template = new TextTemplate("Test", "Desc", "This text has no variables.", TextTemplate.TemplateType.Other);
+        var flowDoc = new FlowDocument(new Paragraph(new Run("This text has no variables.")));
+        var template = new TextTemplate("Test", "Desc", flowDoc, TextTemplate.TemplateType.Other);
 
         // Act
         var foundVariables = template.GetVariables(_mockSupportTool.Object);
@@ -155,7 +158,8 @@ public class TextTemplateTests
     public void Constructor_SetsTemplateTypeCorrectly(TextTemplate.TemplateType type)
     {
         // Arrange & Act
-        var template = new TextTemplate("Name", "Desc", "Text", type);
+        var flowDoc = new FlowDocument(new Paragraph(new Run("Text")));
+        var template = new TextTemplate("Name", "Desc", flowDoc, type);
 
         // Assert
         Assert.Equal(type, template.Type);
@@ -166,15 +170,16 @@ public class TextTemplateTests
     {
         // Arrange
         var id = Guid.NewGuid();
+        var flowDoc = new FlowDocument(new Paragraph(new Run("Text")));
 
         // Act
-        var template = new TextTemplate(id, "Name", "Desc", "Text", TextTemplate.TemplateType.Email);
+        var template = new TextTemplate(id, "Name", "Desc", flowDoc, TextTemplate.TemplateType.Email);
 
         // Assert
         Assert.Equal(id, template.Id);
         Assert.Equal("Name", template.Name);
         Assert.Equal("Desc", template.Description);
-        Assert.Equal("Text", template.Text);
+        Assert.Equal("Text\r\n", TextTemplate.GetFlowDocumentPlainText(template.Text));
         Assert.Equal(TextTemplate.TemplateType.Email, template.Type);
     }
 }

--- a/AMFormsCST.Test/Core/Utils/BestPracticeEnforcerTests.cs
+++ b/AMFormsCST.Test/Core/Utils/BestPracticeEnforcerTests.cs
@@ -3,6 +3,7 @@ using AMFormsCST.Core.Interfaces.Utils;
 using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 using AMFormsCST.Core.Utils;
 using Moq;
+using System.Windows.Documents;
 using Assert = Xunit.Assert;
 
 namespace AMFormsCST.Test.Core.Utils;
@@ -18,7 +19,7 @@ public class BestPracticeEnforcerTests
     {
         _mockFormNamePractice = new Mock<IFormNameBestPractice>();
         _mockTemplateRepository = new Mock<ITemplateRepository>();
-        _templateList = [new TextTemplate("Existing", "Desc", "Text", TextTemplate.TemplateType.Other)];
+        _templateList = [new TextTemplate("Existing", "Desc", new FlowDocument(new Paragraph(new Run("Text"))), TextTemplate.TemplateType.Other)];
 
         // Configure the mock repository to return our in-memory list
         _mockTemplateRepository.Setup(repo => repo.LoadTemplates()).Returns(_templateList);
@@ -45,7 +46,7 @@ public class BestPracticeEnforcerTests
     public void AddTemplate_AddsToCollection_AndSaves()
     {
         // Arrange
-        var newTemplate = new TextTemplate("New", "New Desc", "New Text", TextTemplate.TemplateType.Other);
+        var newTemplate = new TextTemplate("New", "New Desc", new FlowDocument(new Paragraph(new Run("New Text"))), TextTemplate.TemplateType.Other);
 
         // Act
         _enforcer.AddTemplate(newTemplate);
@@ -81,7 +82,7 @@ public class BestPracticeEnforcerTests
     public void AddTemplate_WithEmptyText_ThrowsArgumentException()
     {
         // Arrange
-        var templateWithEmptyText = new TextTemplate("New", "Desc", "", TextTemplate.TemplateType.Other);
+        var templateWithEmptyText = new TextTemplate("New", "Desc", new FlowDocument(), TextTemplate.TemplateType.Other);
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => _enforcer.AddTemplate(templateWithEmptyText));
@@ -105,7 +106,7 @@ public class BestPracticeEnforcerTests
     public void RemoveTemplate_WithNonExistingTemplate_ThrowsArgumentException()
     {
         // Arrange
-        var nonExistingTemplate = new TextTemplate("Non-existent", "Desc", "Text", TextTemplate.TemplateType.Other);
+        var nonExistingTemplate = new TextTemplate("Non-existent", "Desc", new FlowDocument(new Paragraph(new Run("Text"))), TextTemplate.TemplateType.Other);
 
         // Act & Assert
         Assert.Throws<ArgumentException>(() => _enforcer.RemoveTemplate(nonExistingTemplate));
@@ -116,7 +117,7 @@ public class BestPracticeEnforcerTests
     {
         // Arrange
         var originalTemplate = _templateList[0];
-        var updatedTemplate = new TextTemplate(originalTemplate.Id, "Updated Name", "Updated Desc", "Updated Text", TextTemplate.TemplateType.Other);
+        var updatedTemplate = new TextTemplate(originalTemplate.Id, "Updated Name", "Updated Desc", new FlowDocument(new Paragraph(new Run("Updated Text"))), TextTemplate.TemplateType.Other);
 
         // Act
         _enforcer.UpdateTemplate(updatedTemplate);
@@ -134,7 +135,7 @@ public class BestPracticeEnforcerTests
     {
         // Arrange
         // Create a template with a new, unknown Guid
-        var nonExistingTemplate = new TextTemplate(Guid.NewGuid(), "Non-existent", "Desc", "Text", TextTemplate.TemplateType.Other);
+        var nonExistingTemplate = new TextTemplate(Guid.NewGuid(), "Non-existent", "Desc", new FlowDocument(new Paragraph(new Run("Text"))), TextTemplate.TemplateType.Other);
 
         // Act
         // This should not throw an exception.

--- a/AMFormsCST.Test/Core/Utils/TemplateRepositoryTests.cs
+++ b/AMFormsCST.Test/Core/Utils/TemplateRepositoryTests.cs
@@ -2,6 +2,7 @@ using AMFormsCST.Core.Interfaces.Utils;
 using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 using Moq;
 using System.Collections.Generic;
+using System.Windows.Documents;
 using Xunit;
 
 namespace AMFormsCST.Test.Core.Utils;
@@ -14,7 +15,7 @@ public class TemplateRepositoryTests
         var mockRepo = new Mock<ITemplateRepository>();
         var expectedList = new List<TextTemplate>
         {
-            new TextTemplate("T1", "D1", "Text1", TextTemplate.TemplateType.Other)
+            new TextTemplate("T1", "D1", new FlowDocument(new Paragraph(new Run("Text1"))), TextTemplate.TemplateType.Other)
         };
         mockRepo.Setup(r => r.LoadTemplates()).Returns(expectedList);
 
@@ -35,7 +36,7 @@ public class TemplateRepositoryTests
 
         var templates = new List<TextTemplate>
         {
-            new TextTemplate("T1", "D1", "Text1", TextTemplate.TemplateType.Other)
+            new TextTemplate("T1", "D1", new FlowDocument(new Paragraph(new Run("Text1"))), TextTemplate.TemplateType.Other)
         };
 
         var ex = Record.Exception(() => mockRepo.Object.SaveTemplates(templates));

--- a/AMFormsCST.Test/Desktop/Models/Notebook/FormModelTests.cs
+++ b/AMFormsCST.Test/Desktop/Models/Notebook/FormModelTests.cs
@@ -2,6 +2,7 @@ using AMFormsCST.Desktop.Interfaces;
 using AMFormsCST.Desktop.Models;
 using Moq;
 using System.Linq;
+using System.Windows.Documents;
 using Xunit;
 using CoreForm = AMFormsCST.Core.Types.Notebook.Form;
 
@@ -45,7 +46,7 @@ public class FormModelTests
 
         // Act
         form.Name = name;
-        form.Notes = notes;
+        form.Notes = new FlowDocument(new Paragraph(new Run(notes)));
 
         // Assert
         Assert.False(form.IsBlank);
@@ -90,7 +91,7 @@ public class FormModelTests
         var formModel = new Form(null)
         {
             Name = "F1",
-            Notes = "N1",
+            Notes = new FlowDocument(new Paragraph(new Run("N1"))),
             Notable = true
         };
         // The constructor already adds a blank TestDeal. We add a second, non-blank one.
@@ -103,7 +104,7 @@ public class FormModelTests
         // Assert
         Assert.Equal(formModel.Id, coreForm.Id);
         Assert.Equal("F1", coreForm.Name);
-        Assert.Equal("N1", coreForm.Notes);
+        Assert.Equal("N1", coreForm.Notes.Trim());
         Assert.True(coreForm.Notable);
 
         // The test should account for the blank item that is part of the collection.

--- a/AMFormsCST.Test/Desktop/Models/Notebook/NoteModelConversionTests.cs
+++ b/AMFormsCST.Test/Desktop/Models/Notebook/NoteModelConversionTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using CoreNote = AMFormsCST.Core.Types.Notebook.Note;
 using Assert = Xunit.Assert;
+using System.Windows.Documents;
 
 namespace AMFormsCST.Test.Desktop.Models.Notebook;
 
@@ -17,7 +18,7 @@ public class NoteModelConversionTests
         var noteModel = new NoteModel(TestExtSeparator)
         {
             CaseNumber = "CS12345",
-            Notes = "This is a test note.",
+            Notes = new FlowDocument(new Paragraph(new Run("This is a test note."))),
         };
 
         // Populate a dealer and its company
@@ -52,7 +53,7 @@ public class NoteModelConversionTests
         // Assert
         Assert.NotNull(coreNote);
         Assert.Equal("CS12345", coreNote.CaseText);
-        Assert.Equal("This is a test note.", coreNote.NotesText);
+        Assert.Equal("This is a test note.", coreNote.NotesText.Trim());
 
         // Assert Dealer and Company (expecting 2 items: 1 blank, 1 with data)
         Assert.Equal(2, coreNote.Dealers.Count);

--- a/AMFormsCST.Test/Desktop/Models/Notebook/NoteModelTests.cs
+++ b/AMFormsCST.Test/Desktop/Models/Notebook/NoteModelTests.cs
@@ -1,6 +1,7 @@
 using AMFormsCST.Desktop.Interfaces;
 using AMFormsCST.Desktop.Models;
 using System.Linq;
+using System.Windows.Documents;
 using Xunit;
 using CoreNote = AMFormsCST.Core.Types.Notebook.Note;
 
@@ -67,7 +68,7 @@ public class NoteModelTests
 
         // Act
         note.CaseNumber = caseNumber;
-        note.Notes = notes;
+        note.Notes = new FlowDocument(new Paragraph(new Run(notes)));
 
         // Assert
         Assert.False(note.IsBlank);
@@ -112,7 +113,7 @@ public class NoteModelTests
         var noteModel = new NoteModel(TestExtSeparator, null)
         {
             CaseNumber = "98765",
-            Notes = "Test case notes."
+            Notes = new FlowDocument(new Paragraph(new Run("Test case notes.")))
         };
 
         var dealer = new Dealer(null) { Name = "Test Dealer", ServerCode = "SVR1" };
@@ -133,7 +134,7 @@ public class NoteModelTests
 
         // Assert
         Assert.Equal("98765", coreNote.CaseText);
-        Assert.Equal("Test case notes.", coreNote.NotesText);
+        Assert.Equal("Test case notes.", coreNote.NotesText.Trim());
 
         Assert.Equal(2, coreNote.Dealers.Count);
         var coreDealer = coreNote.Dealers.FirstOrDefault(d => !string.IsNullOrEmpty(d.Name));
@@ -170,10 +171,10 @@ public class NoteModelTests
 
         // Act
         noteModel.CaseNumber = "CS123";
-        noteModel.Notes = "Test Notes";
+        noteModel.Notes = new FlowDocument(new Paragraph(new Run("Test Notes")));
 
         // Assert
         Assert.Equal("CS123", coreNote.CaseText);
-        Assert.Equal("Test Notes", coreNote.NotesText);
+        Assert.Equal("Test Notes", coreNote.NotesText.Trim());
     }
 }

--- a/AMFormsCST.Test/Desktop/Models/Templates/DeprecatedTemplateTests.cs
+++ b/AMFormsCST.Test/Desktop/Models/Templates/DeprecatedTemplateTests.cs
@@ -1,8 +1,9 @@
-﻿using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
+﻿    using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 using AMFormsCST.Desktop.Models.Templates;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Windows.Documents;
 using Xunit;
 
 namespace AMFormsCST.Test.Desktop.Models.Templates;
@@ -30,7 +31,7 @@ public class DeprecatedTemplateTests
         var template = new DeprecatedTemplate("Test", text, variables, new List<string>(defaults), DeprecatedTemplate.TemplateType.Other);
         var converted = (TextTemplate)template;
 
-        Assert.Equal(expected, converted.Text);
+        Assert.Equal(expected + "\r\n", TextTemplate.GetFlowDocumentPlainText(converted.Text));
         Assert.Equal("Test", converted.Name);
         Assert.Equal("[Converted]", converted.Description);
         Assert.Equal(TextTemplate.TemplateType.Other, converted.Type);
@@ -44,7 +45,7 @@ public class DeprecatedTemplateTests
         var converted = (TextTemplate)template;
 
         // Should fallback to raw text
-        Assert.Equal("Value: {0} {1}", converted.Text);
+        Assert.Equal("Value: {0} {1}\r\n", TextTemplate.GetFlowDocumentPlainText(converted.Text));
     }
 
     [Fact]

--- a/AMFormsCST.Test/Desktop/ViewModels/Dialogs/NewTemplateDialogViewModelTests.cs
+++ b/AMFormsCST.Test/Desktop/ViewModels/Dialogs/NewTemplateDialogViewModelTests.cs
@@ -3,6 +3,8 @@ using System.Windows;
 using Xunit;
 using Moq;
 using AMFormsCST.Test.Helpers;
+using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
+using System.Windows.Documents;
 
 namespace AMFormsCST.Test.Desktop.ViewModels.Dialogs;
 public class NewTemplateDialogViewModelTests
@@ -16,7 +18,7 @@ public class NewTemplateDialogViewModelTests
         // Assert
         Assert.Equal(string.Empty, vm.TemplateName);
         Assert.Equal(string.Empty, vm.TemplateDescription);
-        Assert.Equal(string.Empty, vm.TemplateContent);
+        Assert.Equal(string.Empty, TextTemplate.GetFlowDocumentPlainText(vm.TemplateContent));
     }
 
     [Fact]
@@ -28,11 +30,11 @@ public class NewTemplateDialogViewModelTests
         // Act
         vm.TemplateName = "Name";
         vm.TemplateDescription = "Desc";
-        vm.TemplateContent = "Content";
+        vm.TemplateContent = new FlowDocument(new Paragraph(new Run("Content")));
 
         // Assert
         Assert.Equal("Name", vm.TemplateName);
         Assert.Equal("Desc", vm.TemplateDescription);
-        Assert.Equal("Content", vm.TemplateContent);
+        Assert.Equal("Content", TextTemplate.GetFlowDocumentPlainText(vm.TemplateContent).Trim());
     }
 }

--- a/AMFormsCST.Test/Desktop/ViewModels/Pages/DashboardViewModelTests.cs
+++ b/AMFormsCST.Test/Desktop/ViewModels/Pages/DashboardViewModelTests.cs
@@ -11,6 +11,7 @@ using System;
 using CoreNote = AMFormsCST.Core.Types.Notebook.Note;
 using Assert = Xunit.Assert;
 using CollectionMemberState = AMFormsCST.Desktop.Interfaces.IManagedObservableCollectionItem.CollectionMemberState;
+using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 
 namespace AMFormsCST.Test.Desktop.ViewModels.Pages;
 
@@ -516,7 +517,7 @@ Web Browser: 11
         // Assert
         Assert.NotNull(note);
         Assert.Equal(expectedCaseNumber, note.CaseNumber);
-        Assert.Equal(expectedNotes, note.Notes);
+        Assert.Equal(expectedNotes, TextTemplate.GetFlowDocumentPlainText(note.Notes).Trim());
 
         Assert.Equal(2, note.Dealers.Count);
         var dealer = note.Dealers[0];

--- a/AMFormsCST.Test/Desktop/ViewModels/Pages/Tools/Pages/TemplatesViewModelTests.cs
+++ b/AMFormsCST.Test/Desktop/ViewModels/Pages/Tools/Pages/TemplatesViewModelTests.cs
@@ -8,6 +8,7 @@ using AMFormsCST.Desktop.ViewModels.Pages.Tools;
 using Moq;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Documents;
 using Assert = Xunit.Assert;
 
 namespace AMFormsCST.Test.Desktop.ViewModels.Pages.Tools.Pages;
@@ -35,8 +36,8 @@ public class TemplatesViewModelTests
         // 2. Create a list of templates to be returned by the mock enforcer
         _templateList =
         [
-            new TextTemplate("Template 1", "Desc 1", "Text 1", TextTemplate.TemplateType.Other),
-            new TextTemplate("Template 2", "Desc 2", "Text 2", TextTemplate.TemplateType.Email)
+            new TextTemplate("Template 1", "Desc 1", new FlowDocument(new Paragraph(new Run("Text 1"))), TextTemplate.TemplateType.Other),
+            new TextTemplate("Template 2", "Desc 2", new FlowDocument(new Paragraph(new Run("Text 2"))), TextTemplate.TemplateType.Email)
         ];
 
         // 3. Configure the full dependency chain required by the view models

--- a/AMFormsCST.Test/Desktop/ViewModels/Pages/Tools/Templates/TemplateItemViewModelTests.cs
+++ b/AMFormsCST.Test/Desktop/ViewModels/Pages/Tools/Templates/TemplateItemViewModelTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using System;
 using System.Collections.ObjectModel;
 using Xunit;
+using System.Windows.Documents;
 
 namespace AMFormsCST.Test.Desktop.ViewModels.Pages.Tools.Templates;
 
@@ -13,7 +14,7 @@ public class TemplateItemViewModelTests
     private static TextTemplate CreateTextTemplate(string text = "Hello {0}!", string name = "Test", string description = "Desc")
     {
         var templateType = TextTemplate.TemplateType.Other;
-        return new TextTemplate(name, description, text, templateType);
+        return new TextTemplate(name, description, new FlowDocument(new Paragraph(new Run(text))), templateType);
     }
 
     private static Mock<ISupportTool> CreateSupportToolMock()

--- a/AMFormsCST.Test/Desktop/Views/Dialogs/NewTemplateDialogTests.cs
+++ b/AMFormsCST.Test/Desktop/Views/Dialogs/NewTemplateDialogTests.cs
@@ -6,6 +6,8 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using Xunit;
 using AMFormsCST.Test.Helpers;
+using System.Windows.Documents;
+using AMFormsCST.Core.Types.BestPractices.TextTemplates.Models;
 
 namespace AMFormsCST.Test.Desktop.Views.Dialogs;
 [Collection("STA Tests")]
@@ -15,24 +17,24 @@ public class NewTemplateDialogTests
     public void Constructor_InitializesDataContextAndProperties()
     {
         // Act
-        var dialog = new NewTemplateDialog("Name", "Desc", "Content");
+        var dialog = new NewTemplateDialog("Name", "Desc", new FlowDocument(new Paragraph(new Run("Content"))));
 
         // Assert
         Assert.IsType<NewTemplateDialogViewModel>(dialog.DataContext);
         var vm = (NewTemplateDialogViewModel)dialog.DataContext;
         Assert.Equal("Name", vm.TemplateName);
         Assert.Equal("Desc", vm.TemplateDescription);
-        Assert.Equal("Content", vm.TemplateContent);
+        Assert.Equal("Content", TextTemplate.GetFlowDocumentPlainText(vm.TemplateContent).Trim());
         Assert.Equal("Name", dialog.TemplateName);
         Assert.Equal("Desc", dialog.TemplateDescription);
-        Assert.Equal("Content", dialog.TemplateContent);
+        Assert.Equal("Content", dialog.TemplateContent.Trim());
     }
 
     [WpfFact]
     public void Constructor_SetsConfirmButtonContentToUpdate_WhenAnyFieldIsNotEmpty()
     {
         // Act
-        var dialog = new NewTemplateDialog("Name", "Desc", "Content");
+        var dialog = new NewTemplateDialog("Name", "Desc", new FlowDocument(new Paragraph(new Run("Content"))));
 
         // Assert
         Assert.Equal("Update", dialog.ConfirmButton.Content);
@@ -52,7 +54,7 @@ public class NewTemplateDialogTests
     public void CustomTitleBarArea_MouseLeftButtonDown_CallsDragMove()
     {
         // Arrange
-        var dialog = new NewTemplateDialog("Name", "Desc", "Content");
+        var dialog = new NewTemplateDialog("Name", "Desc", new FlowDocument(new Paragraph(new Run("Content"))));
         var mouseEvent = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
         {
             RoutedEvent = UIElement.MouseLeftButtonDownEvent,


### PR DESCRIPTION
Introduced `FlowDocument` for rich text formatting in templates and notes, replacing plain text. Added `RichTextToolbar` for editing `RichTextBox` content and `RichTextBoxHelper` for two-way binding. Updated `TextTemplate` serialization with `TextTemplateJsonConverter` to handle XAML and plain text.

Enhanced `IForm` and `NoteModel` to support `FlowDocument` and added a `FormFormat` enum. Updated `TemplateItemViewModel` to process placeholders in `FlowDocument`. Added `FlowDocumentToTextConverter` for clipboard operations.

Refactored UI components (`DashboardPage`, `TemplatesPage`, `NewTemplateDialog`) to use `RichTextBox` with rich text editing capabilities. Updated `DialogService` and design-time tools to support `FlowDocument`. Adjusted project files to include new dependencies and helper classes.